### PR TITLE
Do not interact with Discord RPC if Discord is disabled already

### DIFF
--- a/Mafia2Libs/Utils/DiscordRPC/DiscordController.cs
+++ b/Mafia2Libs/Utils/DiscordRPC/DiscordController.cs
@@ -21,6 +21,16 @@ namespace Utils.Discord
             DiscordRPC.Initialize(applicationId, ref handlers, true, optionalSteamId);
         }
 
+        public void UpdatePresence()
+        {
+            DiscordRPC.UpdatePresence(ref presence);
+        }
+
+        public void Shutdown()
+        {
+            DiscordRPC.Shutdown();
+        }
+
         public void ReadyCallback()
         {
             Console.WriteLine("Discord RPC is ready!");

--- a/Mafia2Libs/Utils/Settings/ToolkitSettings.cs
+++ b/Mafia2Libs/Utils/Settings/ToolkitSettings.cs
@@ -135,7 +135,7 @@ namespace Utils.Settings
         {
             if (!DiscordEnabled)
             {
-                DiscordRPC.Shutdown();
+                controller?.Shutdown();
                 controller = null;
             }
             else
@@ -151,7 +151,7 @@ namespace Utils.Settings
                 controller.presence.details = DiscordDetailsEnabled ? vString : null;
                 controller.presence.startTimestamp = DiscordElapsedTimeEnabled ? ElapsedTime : 0;
 
-                DiscordRPC.UpdatePresence(ref controller.presence);
+                controller.UpdatePresence();
             }
         }
     }


### PR DESCRIPTION
Bundled discord-rpc doesn't work under Wine on Linux, so I have disabled it via `ini`.
The problem is that there are still calls to `DiscordRPC.Shutdown()` even if it's already disabled, e.g. when opening `Options` window.
To avoid that I moved all RPC interactions to `DiscordController`, and if it's `null` there are no calls to the RPC.