### PR TITLE
Do not crash if Icon.ExtractAssociatedIcon returns null

### DIFF
--- a/Mafia2Libs/Forms/GameExplorer.cs
+++ b/Mafia2Libs/Forms/GameExplorer.cs
@@ -199,7 +199,11 @@ namespace Mafia2Tool
             {
                 if (!imageBank.Images.ContainsKey(info.Extension))
                 {
-                    imageBank.Images.Add(info.Extension, Icon.ExtractAssociatedIcon(info.FullName));
+                    var icon = Icon.ExtractAssociatedIcon(info.FullName);
+                    if (icon != null)
+                    {
+                        imageBank.Images.Add(info.Extension, icon);
+                    }
                 }
 
                 if (searchMode && !string.IsNullOrEmpty(filename))


### PR DESCRIPTION
Another fix required to launch toolkit under Wine.
At first I thought it was a Wine problem, but it looks like `Icon.ExtractAssociatedIcon` can actually return `null` in some situations:
https://referencesource.microsoft.com/#System.Drawing/commonui/System/Drawing/Icon.cs,289

So we better check for null here -- the worst case is just missing icons:
![image](https://user-images.githubusercontent.com/2954604/97037636-3a176980-1572-11eb-9d75-b8f8a8006b4f.png)
