### PR TITLE
Add sdsconfig streammap tools to MCP

### DIFF
--- a/Mafia2Libs/MCP/Tools/SdsConfigTools.cs
+++ b/Mafia2Libs/MCP/Tools/SdsConfigTools.cs
@@ -1,0 +1,193 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using ResourceTypes.SDSConfig;
+
+namespace Mafia2Tool.MCP.Tools;
+
+/// <summary>
+/// MCP tools for browsing and inspecting sdsconfig.bin (SDS resource configuration) files
+/// </summary>
+[McpServerToolType]
+public class SdsConfigTools
+{
+    [McpServerTool(Name = "open_sds_config"), Description("Parse sdsconfig.bin and return overview: magic, version, and list of template names with counts. The file is located at <GameRoot>\\EDIT\\sdsconfig.bin")]
+    public string OpenSdsConfig([Description("Full path to sdsconfig.bin (located at <GameRoot>\\EDIT\\sdsconfig.bin)")] string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var config = new SdsConfigFile(new FileInfo(filePath));
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                magic = $"0x{SdsConfigFile.Magic:X8}",
+                version = SdsConfigFile.Version,
+                templateCount = config.Template.Length,
+                templates = config.Template.Select((t, i) => new
+                {
+                    index = i,
+                    name = t.Name,
+                    baseSDSReferenceCount = t.BaseSDSReferences.Length,
+                    virtualSlotCount = t.VirtualSlots.Length
+                }).ToList()
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_sds_config_template"), Description("Get full detail for one template by index or name: BaseSDSReferences (Group[]) and VirtualSlots with nested SDSItems and SDSReferences. The file is located at <GameRoot>\\EDIT\\sdsconfig.bin")]
+    public string GetSdsConfigTemplate(
+        [Description("Full path to sdsconfig.bin (located at <GameRoot>\\EDIT\\sdsconfig.bin)")] string filePath,
+        [Description("Template index (0-based); use -1 to search by name instead")] int templateIndex = -1,
+        [Description("Template name to look up (used when templateIndex is -1)")] string? templateName = null)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var config = new SdsConfigFile(new FileInfo(filePath));
+
+            Template? template = null;
+            int resolvedIndex = templateIndex;
+
+            if (templateIndex >= 0)
+            {
+                if (templateIndex >= config.Template.Length)
+                    return JsonSerializer.Serialize(new { success = false, error = $"Template index {templateIndex} out of range (0-{config.Template.Length - 1})" });
+
+                template = config.Template[templateIndex];
+            }
+            else if (!string.IsNullOrEmpty(templateName))
+            {
+                resolvedIndex = Array.FindIndex(config.Template, t => t.Name.Equals(templateName, StringComparison.OrdinalIgnoreCase));
+                if (resolvedIndex < 0)
+                    return JsonSerializer.Serialize(new { success = false, error = $"Template '{templateName}' not found" });
+
+                template = config.Template[resolvedIndex];
+            }
+            else
+            {
+                return JsonSerializer.Serialize(new { success = false, error = "Provide templateIndex >= 0 or a templateName" });
+            }
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                index = resolvedIndex,
+                name = template.Name,
+                baseSDSReferences = template.BaseSDSReferences.Select(g => new
+                {
+                    name = g.Name,
+                    count = g.Count,
+                    typeId = g.TypeId,
+                    priority = g.Priority,
+                    memorySize = g.MemorySize,
+                    auxSize = g.AuxSize
+                }).ToList(),
+                virtualSlots = template.VirtualSlots.Select(vs => new
+                {
+                    name = vs.Name,
+                    memoryBudget1 = vs.MemoryBudget1,
+                    memoryBudget2 = vs.MemoryBudget2,
+                    sdsItems = vs.SDSItems.Select(item => new
+                    {
+                        name = item.Name,
+                        totalSize1 = item.TotalSize1,
+                        totalSize2 = item.TotalSize2,
+                        flags = item.Flags,
+                        isDefault = item.IsDefault,
+                        sdsReferences = item.SDSReferences.Select(r => new
+                        {
+                            name = r.Name,
+                            count = r.Count,
+                            typeId = r.TypeId,
+                            priority = r.Priority,
+                            memorySize = r.MemorySize,
+                            auxSize = r.AuxSize
+                        }).ToList()
+                    }).ToList()
+                }).ToList()
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "search_sds_config"), Description("Search all template/slot/item/reference names in sdsconfig.bin by case-insensitive substring pattern. The file is located at <GameRoot>\\EDIT\\sdsconfig.bin")]
+    public string SearchSdsConfig(
+        [Description("Full path to sdsconfig.bin (located at <GameRoot>\\EDIT\\sdsconfig.bin)")] string filePath,
+        [Description("Search pattern (case-insensitive substring)")] string pattern,
+        [Description("Maximum results per category (default: 50)")] int limit = 50)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var config = new SdsConfigFile(new FileInfo(filePath));
+            limit = Math.Clamp(limit, 1, 200);
+
+            var matchedTemplates = config.Template
+                .Select((t, i) => new { t, i })
+                .Where(x => x.t.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                .Select(x => new { index = x.i, name = x.t.Name })
+                .ToList();
+
+            var matchedBaseRefs = config.Template
+                .SelectMany((t, ti) => t.BaseSDSReferences
+                    .Where(g => g.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                    .Select(g => new { templateIndex = ti, templateName = t.Name, name = g.Name }))
+                .ToList();
+
+            var matchedSlots = config.Template
+                .SelectMany((t, ti) => t.VirtualSlots
+                    .Select((vs, vi) => new { ti, t, vs, vi })
+                    .Where(x => x.vs.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                    .Select(x => new { templateIndex = x.ti, templateName = x.t.Name, slotIndex = x.vi, name = x.vs.Name }))
+                .ToList();
+
+            var matchedItems = config.Template
+                .SelectMany((t, ti) => t.VirtualSlots
+                    .SelectMany((vs, vi) => vs.SDSItems
+                        .Select((item, ii) => new { ti, t, vi, vs, item, ii })
+                        .Where(x => x.item.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                        .Select(x => new { templateIndex = x.ti, templateName = x.t.Name, slotIndex = x.vi, slotName = x.vs.Name, itemIndex = x.ii, name = x.item.Name })))
+                .ToList();
+
+            var matchedSdsRefs = config.Template
+                .SelectMany((t, ti) => t.VirtualSlots
+                    .SelectMany((vs, vi) => vs.SDSItems
+                        .SelectMany((item, ii) => item.SDSReferences
+                            .Where(r => r.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                            .Select(r => new { templateIndex = ti, templateName = t.Name, slotIndex = vi, slotName = vs.Name, itemIndex = ii, itemName = item.Name, name = r.Name }))))
+                .ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                pattern,
+                templates = new { totalMatches = matchedTemplates.Count, results = matchedTemplates.Take(limit).ToList(), hasMore = matchedTemplates.Count > limit },
+                baseSDSReferences = new { totalMatches = matchedBaseRefs.Count, results = matchedBaseRefs.Take(limit).ToList(), hasMore = matchedBaseRefs.Count > limit },
+                virtualSlots = new { totalMatches = matchedSlots.Count, results = matchedSlots.Take(limit).ToList(), hasMore = matchedSlots.Count > limit },
+                sdsItems = new { totalMatches = matchedItems.Count, results = matchedItems.Take(limit).ToList(), hasMore = matchedItems.Count > limit },
+                sdsReferences = new { totalMatches = matchedSdsRefs.Count, results = matchedSdsRefs.Take(limit).ToList(), hasMore = matchedSdsRefs.Count > limit }
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+}

--- a/Mafia2Libs/MCP/Tools/StreamMapTools.cs
+++ b/Mafia2Libs/MCP/Tools/StreamMapTools.cs
@@ -1,0 +1,298 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using ResourceTypes.Misc;
+
+namespace Mafia2Tool.MCP.Tools;
+
+/// <summary>
+/// MCP tools for browsing and inspecting StreamMapa.bin (streaming configuration) files
+/// </summary>
+[McpServerToolType]
+public class StreamMapTools
+{
+    [McpServerTool(Name = "open_stream_map"), Description("Parse StreamMapa.bin and return header overview: group/line/loader/block counts and group list. Main file is at <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have their own copies (e.g. dlcs\\<dlc_name>\\game_edit\\tables\\), but prefer the main file unless searching DLC-specific content")]
+    public string OpenStreamMap([Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                groupCount = streamMap.Groups.Length,
+                groupHeaderCount = streamMap.GroupHeaders.Length,
+                lineCount = streamMap.Lines.Length,
+                loaderCount = streamMap.Loaders.Length,
+                blockCount = streamMap.Blocks.Length,
+                groups = streamMap.Groups.Select(g => new { g.Name, type = g.Type.ToString() }).ToList()
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_stream_groups"), Description("List all StreamGroup entries with type, offsets, and loader index range")]
+    public string GetStreamGroups([Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            var groups = streamMap.Groups.Select((g, i) => new
+            {
+                index = i,
+                name = g.Name,
+                type = g.Type.ToString(),
+                unk01 = g.Unk01,
+                loaderStartOffset = g.startOffset,
+                loaderEndOffset = g.endOffset,
+                loaderCount = g.endOffset - g.startOffset,
+                unk05 = g.Unk05
+            }).ToList();
+
+            return JsonSerializer.Serialize(new { success = true, count = groups.Count, groups });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_stream_lines"), Description("List StreamLine entries with pagination and optional group name filter")]
+    public string GetStreamLines(
+        [Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath,
+        [Description("Filter by group name (case-insensitive substring, optional)")] string? groupFilter = null,
+        [Description("Starting index for pagination (default: 0)")] int offset = 0,
+        [Description("Number of lines to return (default: 100)")] int limit = 100)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            var lines = streamMap.Lines.AsEnumerable();
+
+            if (!string.IsNullOrEmpty(groupFilter))
+                lines = lines.Where(l => l.Group != null && l.Group.Contains(groupFilter, StringComparison.OrdinalIgnoreCase));
+
+            limit = Math.Clamp(limit, 1, 500);
+            var totalCount = lines.Count();
+            var page = lines.Skip(offset).Take(limit).Select((l, i) => new
+            {
+                index = offset + i,
+                name = l.Name,
+                group = l.Group,
+                flags = l.Flags,
+                loadType = l.LoadType,
+                lineID = l.lineID,
+                groupID = l.groupID
+            }).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                pagination = new { offset, limit, count = page.Count, totalCount, hasMore = offset + page.Count < totalCount },
+                groupFilter,
+                lines = page
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_stream_line_detail"), Description("Get full detail for a single StreamLine by index")]
+    public string GetStreamLineDetail(
+        [Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath,
+        [Description("Line index (0-based)")] int lineIndex)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            if (lineIndex < 0 || lineIndex >= streamMap.Lines.Length)
+                return JsonSerializer.Serialize(new { success = false, error = $"Line index {lineIndex} out of range (0-{streamMap.Lines.Length - 1})" });
+
+            var l = streamMap.Lines[lineIndex];
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                index = lineIndex,
+                name = l.Name,
+                group = l.Group,
+                flags = l.Flags,
+                loadType = l.LoadType,
+                lineID = l.lineID,
+                groupID = l.groupID,
+                nameIDX = l.nameIDX,
+                flagIDX = l.flagIDX,
+                unk5 = l.Unk5,
+                unk10 = $"0x{l.Unk10:X16}",
+                unk11 = $"0x{l.Unk11:X16}",
+                unk12 = l.Unk12,
+                unk13 = l.Unk13,
+                unk14 = l.Unk14,
+                unk15 = l.Unk15
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_stream_loaders"), Description("List all StreamLoader entries (assets loaded per streaming group) with pagination")]
+    public string GetStreamLoaders(
+        [Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath,
+        [Description("Starting index for pagination (default: 0)")] int offset = 0,
+        [Description("Number of loaders to return (default: 100)")] int limit = 100)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            limit = Math.Clamp(limit, 1, 500);
+            var totalCount = streamMap.Loaders.Length;
+            var page = streamMap.Loaders.Skip(offset).Take(limit).Select((l, i) => new
+            {
+                index = offset + i,
+                path = l.Path,
+                entity = l.Entity,
+                type = l.Type.ToString(),
+                loadType = l.LoadType,
+                loaderID = l.LoaderID,
+                loaderSubID = l.LoaderSubID,
+                groupID = l.GroupID,
+                assignedGroup = l.AssignedGroup
+            }).ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                pagination = new { offset, limit, count = page.Count, totalCount, hasMore = offset + page.Count < totalCount },
+                loaders = page
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "get_line_load_list"), Description("Get the list of assets (loaders) that will be loaded when a specific StreamLine is activated, by matching loader start/end range against the line's lineID")]
+    public string GetLineLoadList(
+        [Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath,
+        [Description("Line index (0-based)")] int lineIndex)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            if (lineIndex < 0 || lineIndex >= streamMap.Lines.Length)
+                return JsonSerializer.Serialize(new { success = false, error = $"Line index {lineIndex} out of range (0-{streamMap.Lines.Length - 1})" });
+
+            var line = streamMap.Lines[lineIndex];
+            var loadList = streamMap.Loaders
+                .Select((loader, i) => new { loader, i })
+                .Where(x => line.lineID >= x.loader.start && line.lineID <= x.loader.end)
+                .Select(x => new
+                {
+                    index = x.i,
+                    path = x.loader.Path,
+                    entity = x.loader.Entity,
+                    type = x.loader.Type.ToString(),
+                    loadType = x.loader.LoadType,
+                    loaderID = x.loader.LoaderID,
+                    loaderSubID = x.loader.LoaderSubID,
+                    start = x.loader.start,
+                    end = x.loader.end
+                })
+                .ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                lineIndex,
+                lineName = line.Name,
+                lineID = line.lineID,
+                group = line.Group,
+                loadListCount = loadList.Count,
+                loadList
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+
+    [McpServerTool(Name = "search_stream_lines"), Description("Search StreamLine names and StreamLoader paths/entities by case-insensitive substring pattern")]
+    public string SearchStreamLines(
+        [Description("Full path to StreamMapa.bin (main: <GameRoot>\\EDIT\\tables\\StreamMapa.bin; DLCs have copies under dlcs\\<dlc_name>\\game_edit\\tables\\)")] string filePath,
+        [Description("Search pattern (case-insensitive substring)")] string pattern,
+        [Description("Maximum results per category (default: 50)")] int limit = 50)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+                return JsonSerializer.Serialize(new { success = false, error = "File not found" });
+
+            var streamMap = new StreamMapLoader(new FileInfo(filePath));
+            limit = Math.Clamp(limit, 1, 200);
+
+            var matchedLines = streamMap.Lines
+                .Select((l, i) => new { l, i })
+                .Where(x => x.l.Name != null && x.l.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                .Select(x => new { index = x.i, name = x.l.Name, group = x.l.Group, flags = x.l.Flags, loadType = x.l.LoadType })
+                .ToList();
+
+            var matchedLoaders = streamMap.Loaders
+                .Select((l, i) => new { l, i })
+                .Where(x => (x.l.Path != null && x.l.Path.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+                         || (x.l.Entity != null && x.l.Entity.Contains(pattern, StringComparison.OrdinalIgnoreCase)))
+                .Select(x => new { index = x.i, path = x.l.Path, entity = x.l.Entity, type = x.l.Type.ToString(), loadType = x.l.LoadType })
+                .ToList();
+
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                pattern,
+                lines = new
+                {
+                    totalMatches = matchedLines.Count,
+                    results = matchedLines.Take(limit).ToList(),
+                    hasMore = matchedLines.Count > limit
+                },
+                loaders = new
+                {
+                    totalMatches = matchedLoaders.Count,
+                    results = matchedLoaders.Take(limit).ToList(),
+                    hasMore = matchedLoaders.Count > limit
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Create a `.mcp.json` file in your project directory (or add to your Claude Code 
 2. In Claude Code, run `/mcp` to connect to the server
 3. Use the available tools to browse SDS archives and game files
 
-### Available Tools (24 total)
+### Available Tools (34 total)
 
 #### SDS Archive Tools (8 tools)
 
@@ -131,6 +131,30 @@ Create a `.mcp.json` file in your project directory (or add to your Claude Code 
 | `detect_format_from_bytes` | `base64Data`, `extensionHint?` | Detect file format from base64-encoded bytes. Useful for identifying extracted resources. |
 | `convert_number` | `input` | Convert between decimal, hex (0x), and binary (0b). Returns all representations plus signed values and byte array. |
 | `list_game_files` | `directoryPath`, `extensionFilter?`, `recursive` | List game files matching common Mafia extensions (.sds, .mtl, .dds, .act, .nav, .xbin, etc.). |
+
+#### SDS Config Tools (3 tools)
+
+SDS Config (`sdsconfig.bin`) defines how SDS archives are categorized into types, memory budgets, and virtual loading slots. Located at `<GameRoot>\EDIT\sdsconfig.bin`.
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `open_sds_config` | `filePath` | Parse `sdsconfig.bin` and return overview: magic, version, and list of template names with counts. |
+| `get_sds_config_template` | `filePath`, `templateIndex?`, `templateName?` | Get full detail for one template: `BaseSDSReferences` (SDS types with memory/priority budgets) and `VirtualSlots` with nested `SDSItems` and `SDSReferences`. |
+| `search_sds_config` | `filePath`, `pattern`, `limit?` | Search all template/slot/item/reference names by case-insensitive substring. |
+
+#### Stream Map Tools (7 tools)
+
+Stream Map (`StreamMapa.bin`) defines the world streaming grid: which assets load when the player enters a zone. The main file is at `<GameRoot>\EDIT\tables\StreamMapa.bin`; DLCs have their own copies under `dlcs\<dlc_name>\game_edit\tables\` — prefer the main file unless looking for DLC-specific content.
+
+| Tool | Parameters | Description |
+|------|------------|-------------|
+| `open_stream_map` | `filePath` | Parse `StreamMapa.bin` and return header overview: group, line, loader, and block counts plus group list. |
+| `get_stream_groups` | `filePath` | List all `StreamGroup` entries with type, loader index range, and offsets. |
+| `get_stream_lines` | `filePath`, `groupFilter?`, `offset`, `limit` | List `StreamLine` entries with optional group filter and pagination. |
+| `get_stream_line_detail` | `filePath`, `lineIndex` | Get full detail for a single `StreamLine` by index: flags, IDs, and raw unknowns. |
+| `get_stream_loaders` | `filePath`, `offset`, `limit` | List all `StreamLoader` entries (assets loaded per streaming zone) with pagination. |
+| `get_line_load_list` | `filePath`, `lineIndex` | Get the list of assets that will be loaded when a specific `StreamLine` is activated. |
+| `search_stream_lines` | `filePath`, `pattern`, `limit?` | Search `StreamLine` names and `StreamLoader` paths/entities by case-insensitive substring. |
 
 ### Supported Formats
 


### PR DESCRIPTION
## Summary

- `sdsconfig.bin` defines how SDS archives are categorized into types, memory budgets, and virtual loading slots — the metadata that decides which archives the game actually loads. The MCP server previously had no way to introspect this without parsing the binary by hand. Add `Mafia2Libs/MCP/Tools/SdsConfigTools.cs` with `open_sds_config` (magic + version + template overview), `get_sds_config_template` (full `BaseSDSReferences` + `VirtualSlots` for one template by index or name), and `search_sds_config` (case-insensitive substring search across templates, slots, items, references).
- `StreamMapa.bin` defines the world streaming grid: which `StreamLoader` assets get pulled in when a given `StreamLine` is activated. Add `Mafia2Libs/MCP/Tools/StreamMapTools.cs` mirroring the `SdsService` style — `open_stream_map` for the header (group / line / loader / block counts), `get_stream_groups`, paginated `get_stream_lines` (with optional group-name filter) and `get_stream_loaders`, `get_stream_line_detail` for a single entry, `get_line_load_list` to resolve the loaders that activate with a given line, and `search_stream_lines` over line names and loader paths/entities.
- README updated with both new sections so the tool catalogue stays in sync.

No changes to existing parsers or Gibbed code; scope is the MCP layer only.