### PR TITLE
Fix MCP SdsService failing on encrypted stock SDS files

### DIFF
--- a/Mafia2Libs/MCP/McpError.cs
+++ b/Mafia2Libs/MCP/McpError.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Mafia2Tool.MCP;
+
+/// <summary>
+/// Builds a structured error payload that MCP tools can include in their JSON responses.
+/// Surfaces the full exception chain (type + message + first stack frames) so consumers don't
+/// see a bare "InvalidOperationException: Operation is not valid due to the current state of the
+/// object." with no clue where it came from.
+/// </summary>
+public static class McpError
+{
+    private const int MaxDepth = 6;
+    private const int MaxFrames = 10;
+
+    public static object Build(Exception ex, string? fallbackMessage = null)
+    {
+        if (ex == null)
+        {
+            return new { message = fallbackMessage ?? "Unknown error" };
+        }
+
+        // Reflection invoke wraps the real exception in TargetInvocationException; unwrap to surface it.
+        while (ex is TargetInvocationException tie && tie.InnerException != null)
+        {
+            ex = tie.InnerException;
+        }
+
+        var chain = new List<object>();
+        for (Exception? e = ex; e != null && chain.Count < MaxDepth; e = e.InnerException)
+        {
+            chain.Add(new
+            {
+                type = e.GetType().FullName,
+                message = e.Message,
+                stack = SummarizeStack(e.StackTrace),
+            });
+        }
+
+        return new
+        {
+            type = ex.GetType().FullName,
+            message = ex.Message,
+            chain,
+        };
+    }
+
+    private static string[] SummarizeStack(string? stack)
+    {
+        if (string.IsNullOrEmpty(stack)) return Array.Empty<string>();
+        var lines = stack.Split('\n');
+        var trimmed = new List<string>(Math.Min(lines.Length, MaxFrames));
+        for (int i = 0; i < lines.Length && trimmed.Count < MaxFrames; i++)
+        {
+            var line = lines[i].Trim();
+            if (line.Length == 0) continue;
+            trimmed.Add(line);
+        }
+        return trimmed.ToArray();
+    }
+}

--- a/Mafia2Libs/MCP/McpError.cs
+++ b/Mafia2Libs/MCP/McpError.cs
@@ -1,35 +1,40 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Text.Json;
+using Mafia2Tool.MCP.Services;
 
 namespace Mafia2Tool.MCP;
 
 /// <summary>
-/// Builds a structured error payload that MCP tools can include in their JSON responses.
-/// Surfaces the full exception chain (type + message + first stack frames) so consumers don't
-/// see a bare "InvalidOperationException: Operation is not valid due to the current state of the
-/// object." with no clue where it came from.
+/// Helpers for surfacing exception detail in MCP tool responses.
+///
+/// The MCP C# SDK normally hides exception detail behind a generic "An error occurred invoking
+/// 'X'." message to avoid leaking internal implementation. This server is bound to localhost
+/// (see <see cref="McpServerHost"/>) and used as a developer debugging tool, so we deliberately
+/// emit the full type + inner-exception chain + first stack frames into the tool's JSON
+/// response. Without this, repros like "encrypted-SDS fails with InvalidOperationException deep
+/// inside BlockReaderStream" are effectively un-diagnosable from the client.
 /// </summary>
 public static class McpError
 {
-    private const int MaxDepth = 6;
-    private const int MaxFrames = 10;
+    private const int MaxChainDepth = 6;
+    private const int MaxStackFrames = 10;
 
-    public static object Build(Exception ex, string? fallbackMessage = null)
+    /// <summary>
+    /// Builds the structured detail object embedded as <c>errorDetail</c> in tool responses.
+    /// Unwraps <see cref="TargetInvocationException"/> so reflection-invoked failures point at
+    /// the real source.
+    /// </summary>
+    public static object Build(Exception ex)
     {
-        if (ex == null)
-        {
-            return new { message = fallbackMessage ?? "Unknown error" };
-        }
-
-        // Reflection invoke wraps the real exception in TargetInvocationException; unwrap to surface it.
         while (ex is TargetInvocationException tie && tie.InnerException != null)
         {
             ex = tie.InnerException;
         }
 
-        var chain = new List<object>();
-        for (Exception? e = ex; e != null && chain.Count < MaxDepth; e = e.InnerException)
+        var chain = new List<object>(MaxChainDepth);
+        for (Exception? e = ex; e != null && chain.Count < MaxChainDepth; e = e.InnerException)
         {
             chain.Add(new
             {
@@ -38,26 +43,36 @@ public static class McpError
                 stack = SummarizeStack(e.StackTrace),
             });
         }
-
-        return new
-        {
-            type = ex.GetType().FullName,
-            message = ex.Message,
-            chain,
-        };
+        return new { chain };
     }
+
+    /// <summary>
+    /// Serializes the standard <c>{ success = false, error, errorDetail }</c> failure payload
+    /// returned from a catch block.
+    /// </summary>
+    public static string FailJson(Exception ex) =>
+        JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = Build(ex) });
+
+    /// <summary>
+    /// Serializes the failure payload for an <see cref="SdsService.OpenFile"/> miss, forwarding
+    /// the service's structured <see cref="SdsService.LastErrorDetail"/> so the caller sees the
+    /// real cause instead of just "Failed to open SDS file".
+    /// </summary>
+    public static string OpenFailureJson(SdsService service, string fallback = "Failed to open SDS file") =>
+        JsonSerializer.Serialize(new
+        {
+            success = false,
+            error = service.LastError ?? fallback,
+            errorDetail = service.LastErrorDetail,
+        });
 
     private static string[] SummarizeStack(string? stack)
     {
         if (string.IsNullOrEmpty(stack)) return Array.Empty<string>();
-        var lines = stack.Split('\n');
-        var trimmed = new List<string>(Math.Min(lines.Length, MaxFrames));
-        for (int i = 0; i < lines.Length && trimmed.Count < MaxFrames; i++)
-        {
-            var line = lines[i].Trim();
-            if (line.Length == 0) continue;
-            trimmed.Add(line);
-        }
-        return trimmed.ToArray();
+        var lines = stack.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        var take = Math.Min(lines.Length, MaxStackFrames);
+        var trimmed = new string[take];
+        for (int i = 0; i < take; i++) trimmed[i] = lines[i].Trim();
+        return trimmed;
     }
 }

--- a/Mafia2Libs/MCP/Services/SdsService.cs
+++ b/Mafia2Libs/MCP/Services/SdsService.cs
@@ -233,7 +233,7 @@ public class SdsService
         catch (Exception ex)
         {
             LastError = $"{ex.GetType().Name}: {ex.Message}";
-            LastErrorDetail = Mafia2Tool.MCP.McpError.Build(ex);
+            LastErrorDetail = McpError.Build(ex);
             System.Diagnostics.Debug.WriteLine($"[SdsService] Error opening file: {ex}");
             return null;
         }

--- a/Mafia2Libs/MCP/Services/SdsService.cs
+++ b/Mafia2Libs/MCP/Services/SdsService.cs
@@ -106,9 +106,15 @@ public class SdsService
     }
 
     /// <summary>
-    /// Last error encountered during file operations
+    /// Last error encountered during file operations (short message).
     /// </summary>
     public string? LastError { get; private set; }
+
+    /// <summary>
+    /// Structured detail (type, inner-exception chain, stack frames) about the LastError.
+    /// MCP tools surface this so callers can diagnose without re-running the operation.
+    /// </summary>
+    public object? LastErrorDetail { get; private set; }
 
     /// <summary>
     /// Opens an SDS file and returns its metadata
@@ -116,6 +122,7 @@ public class SdsService
     public SdsFileInfo? OpenFile(string filePath, GamesEnumerator? gameType = null)
     {
         LastError = null;
+        LastErrorDetail = null;
         var normalizedPath = Path.GetFullPath(filePath);
 
         // Check cache first
@@ -144,9 +151,13 @@ public class SdsService
                 archive.SetGameType(gameType.Value);
             }
 
-            // Read the SDS file using existing toolkit code
+            // Read the SDS file using existing toolkit code.
+            // Stock game-installed SDS files are TEA-encrypted; ArchiveEncryption.Unwrap detects
+            // that (via the "tables/fsfh.bin" marker at offset 0x90) and returns a decrypted
+            // MemoryStream, or null for unencrypted files. Mirror FileSDS.Open's behavior.
             using var inputStream = File.OpenRead(normalizedPath);
-            archive.Deserialize(inputStream);
+            using var decrypted = ArchiveEncryption.Unwrap(inputStream);
+            archive.Deserialize(decrypted ?? (Stream)inputStream);
 
             // Try to detect game type from version
             var detectedGame = archive.Version switch
@@ -222,6 +233,7 @@ public class SdsService
         catch (Exception ex)
         {
             LastError = $"{ex.GetType().Name}: {ex.Message}";
+            LastErrorDetail = Mafia2Tool.MCP.McpError.Build(ex);
             System.Diagnostics.Debug.WriteLine($"[SdsService] Error opening file: {ex}");
             return null;
         }

--- a/Mafia2Libs/MCP/Tools/MaterialTools.cs
+++ b/Mafia2Libs/MCP/Tools/MaterialTools.cs
@@ -88,7 +88,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -164,7 +164,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -219,7 +219,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -276,7 +276,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/MaterialTools.cs
+++ b/Mafia2Libs/MCP/Tools/MaterialTools.cs
@@ -88,7 +88,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -164,7 +164,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -219,7 +219,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -276,7 +276,7 @@ public class MaterialTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/SdsTools.cs
+++ b/Mafia2Libs/MCP/Tools/SdsTools.cs
@@ -47,7 +47,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -68,7 +68,12 @@ public class SdsTools
 
             if (info == null)
             {
-                return JsonSerializer.Serialize(new { success = false, error = _sdsService.LastError ?? "Failed to open SDS file" });
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = _sdsService.LastError ?? "Failed to open SDS file",
+                    errorDetail = _sdsService.LastErrorDetail,
+                });
             }
 
             var typeGroups = info.Resources
@@ -108,7 +113,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -120,7 +125,12 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new { success = false, error = _sdsService.LastError ?? "Failed to open SDS file" });
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = _sdsService.LastError ?? "Failed to open SDS file",
+                    errorDetail = _sdsService.LastErrorDetail,
+                });
             }
 
             return JsonSerializer.Serialize(new
@@ -144,7 +154,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -160,7 +170,12 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new { success = false, error = _sdsService.LastError ?? "Failed to open SDS file" });
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = _sdsService.LastError ?? "Failed to open SDS file",
+                    errorDetail = _sdsService.LastErrorDetail,
+                });
             }
 
             var resources = info.Resources.AsEnumerable();
@@ -194,7 +209,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -231,7 +246,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -266,7 +281,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -308,7 +323,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -320,7 +335,12 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new { success = false, error = _sdsService.LastError ?? "Failed to open SDS file" });
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = _sdsService.LastError ?? "Failed to open SDS file",
+                    errorDetail = _sdsService.LastErrorDetail,
+                });
             }
 
             var typeStats = info.Resources
@@ -353,7 +373,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/SdsTools.cs
+++ b/Mafia2Libs/MCP/Tools/SdsTools.cs
@@ -47,7 +47,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -68,12 +68,7 @@ public class SdsTools
 
             if (info == null)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    error = _sdsService.LastError ?? "Failed to open SDS file",
-                    errorDetail = _sdsService.LastErrorDetail,
-                });
+                return McpError.OpenFailureJson(_sdsService);
             }
 
             var typeGroups = info.Resources
@@ -113,7 +108,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -125,12 +120,7 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    error = _sdsService.LastError ?? "Failed to open SDS file",
-                    errorDetail = _sdsService.LastErrorDetail,
-                });
+                return McpError.OpenFailureJson(_sdsService);
             }
 
             return JsonSerializer.Serialize(new
@@ -154,7 +144,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -170,12 +160,7 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    error = _sdsService.LastError ?? "Failed to open SDS file",
-                    errorDetail = _sdsService.LastErrorDetail,
-                });
+                return McpError.OpenFailureJson(_sdsService);
             }
 
             var resources = info.Resources.AsEnumerable();
@@ -209,7 +194,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -246,7 +231,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -281,7 +266,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -323,7 +308,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -335,12 +320,7 @@ public class SdsTools
             var info = _sdsService.OpenFile(filePath);
             if (info == null)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    error = _sdsService.LastError ?? "Failed to open SDS file",
-                    errorDetail = _sdsService.LastErrorDetail,
-                });
+                return McpError.OpenFailureJson(_sdsService);
             }
 
             var typeStats = info.Resources
@@ -373,7 +353,7 @@ public class SdsTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/TextureTools.cs
+++ b/Mafia2Libs/MCP/Tools/TextureTools.cs
@@ -63,7 +63,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -131,7 +131,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -145,7 +145,12 @@ public class TextureTools
             var sdsInfo = _sdsService.OpenFile(sdsPath);
             if (sdsInfo == null)
             {
-                return JsonSerializer.Serialize(new { success = false, error = _sdsService.LastError ?? "Failed to open SDS file" });
+                return JsonSerializer.Serialize(new
+                {
+                    success = false,
+                    error = _sdsService.LastError ?? "Failed to open SDS file",
+                    errorDetail = _sdsService.LastErrorDetail,
+                });
             }
 
             var textures = sdsInfo.Resources
@@ -222,7 +227,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -250,7 +255,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/TextureTools.cs
+++ b/Mafia2Libs/MCP/Tools/TextureTools.cs
@@ -63,7 +63,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -131,7 +131,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -145,12 +145,7 @@ public class TextureTools
             var sdsInfo = _sdsService.OpenFile(sdsPath);
             if (sdsInfo == null)
             {
-                return JsonSerializer.Serialize(new
-                {
-                    success = false,
-                    error = _sdsService.LastError ?? "Failed to open SDS file",
-                    errorDetail = _sdsService.LastErrorDetail,
-                });
+                return McpError.OpenFailureJson(_sdsService);
             }
 
             var textures = sdsInfo.Resources
@@ -227,7 +222,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -255,7 +250,7 @@ public class TextureTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/UtilityTools.cs
+++ b/Mafia2Libs/MCP/Tools/UtilityTools.cs
@@ -48,7 +48,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -74,7 +74,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -110,7 +110,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -158,7 +158,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -187,7 +187,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -227,7 +227,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -295,7 +295,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 
@@ -342,7 +342,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message });
+            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
         }
     }
 

--- a/Mafia2Libs/MCP/Tools/UtilityTools.cs
+++ b/Mafia2Libs/MCP/Tools/UtilityTools.cs
@@ -48,7 +48,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -74,7 +74,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -110,7 +110,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -158,7 +158,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -187,7 +187,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -227,7 +227,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -295,7 +295,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 
@@ -342,7 +342,7 @@ public class UtilityTools
         }
         catch (Exception ex)
         {
-            return JsonSerializer.Serialize(new { success = false, error = ex.Message, errorDetail = McpError.Build(ex) });
+            return McpError.FailJson(ex);
         }
     }
 


### PR DESCRIPTION
## Summary

- Stock game-installed Mafia II SDS archives are TEA-encrypted (`tables/fsfh.bin` marker at offset 0x90). `FileSDS.Open` already pipes the input through `ArchiveEncryption.Unwrap` before deserializing; `SdsService.OpenFile` (the MCP path) did not, so the parser read ciphertext and threw a bare `InvalidOperationException` inside `BlockReaderStream.FromStream`. Repro: `D:\SteamLibrary\steamapps\common\Mafia II\pc\sds\tables\tables.sds`. The `mafia2-parser` CLI's "corrupt deflate stream" error has the same root cause — it was trying to inflate ciphertext.
- Mirror `FileSDS.Open` in `SdsService.OpenFile` so the MCP path handles both encrypted and unencrypted archives.
- Add `Mafia2Libs/MCP/McpError.cs` and wire every MCP tool catch block to emit `errorDetail` (type + inner-exception chain + first stack frames) alongside the existing `error` message. The "Failed to open SDS file" branches in `SdsTools` and `TextureTools.ListSdsTextures` now also forward `SdsService.LastErrorDetail`, so callers never see an opaque single-line `InvalidOperationException` again.

No changes to Gibbed library code; scope is the MCP layer only.

## Test plan

- [x] `dotnet build` clean (0 errors).
- [x] Verified through `SdsService.OpenFile` against the failing Steam `tables.sds`: was `InvalidOperationException`, now returns 152 entries / 4 types.
- [x] Verified against the previously-working unencrypted `tables.sds`: still returns 152 entries / 4 types (no regression).
- [x] Verified the error path on a deliberately bogus file: now returns `FormatException: Unsupported Archive Signature: 1852797984` with a stack frame at `ArchiveFile.cs:line 242`, replacing the old opaque "Operation is not valid due to the current state of the object."
- [ ] Manual smoke-test in the running MCP server (rebuild + restart required) — e.g. `open_sds_file` / `get_sds_header` / `list_resources` against a stock Mafia II install.