### PR TITLE
Add Mafia II .eff (Effects) file format support

### DIFF
--- a/Mafia2Libs/Core/IO/FileEffects.cs
+++ b/Mafia2Libs/Core/IO/FileEffects.cs
@@ -1,0 +1,27 @@
+using Toolkit.Forms;
+using System.IO;
+
+namespace Core.IO
+{
+    /// <summary>
+    /// File handler for ".eff" — the payload of an SDS "Effects" resource (Mafia II).
+    /// Opens the chunk-tree editor.
+    /// </summary>
+    public class FileEffects : FileBase
+    {
+        public FileEffects(FileInfo info) : base(info)
+        {
+        }
+
+        public override string GetExtensionUpper()
+        {
+            return "EFF";
+        }
+
+        public override bool Open()
+        {
+            EffectsEditor editor = new EffectsEditor(file);
+            return true;
+        }
+    }
+}

--- a/Mafia2Libs/Core/IO/FileFactory.cs
+++ b/Mafia2Libs/Core/IO/FileFactory.cs
@@ -86,6 +86,8 @@ namespace Core.IO
                     return new FileAnimation2(info);
                 case "FNT":
                     return new FileFNT(info);
+                case "EFF":
+                    return new FileEffects(info);
                 default:
                     return new FileBase(info);
             }

--- a/Mafia2Libs/Forms/EffectsEditor.cs
+++ b/Mafia2Libs/Forms/EffectsEditor.cs
@@ -2,6 +2,7 @@ using ResourceTypes.Effects;
 using System;
 using System.IO;
 using System.Windows.Forms;
+using Utils.Language;
 
 namespace Toolkit.Forms
 {
@@ -35,29 +36,29 @@ namespace Toolkit.Forms
 
         private void BuildUi()
         {
-            Text = "Effects Editor - " + effFile.Name;
+            Text = TitleText(false);
             ClientSize = new System.Drawing.Size(900, 560);
             KeyPreview = true;
 
             MenuStrip menu = new MenuStrip();
 
-            ToolStripMenuItem fileMenu = new ToolStripMenuItem("File");
-            ToolStripMenuItem saveItem = new ToolStripMenuItem("Save", null, (s, e) => Save())
+            ToolStripMenuItem fileMenu = new ToolStripMenuItem(Language.GetString("$FILE"));
+            ToolStripMenuItem saveItem = new ToolStripMenuItem(Language.GetString("$SAVE"), null, (s, e) => Save())
             {
                 ShortcutKeys = Keys.Control | Keys.S
             };
-            ToolStripMenuItem reloadItem = new ToolStripMenuItem("Reload", null, (s, e) => Reload())
+            ToolStripMenuItem reloadItem = new ToolStripMenuItem(Language.GetString("$RELOAD"), null, (s, e) => Reload())
             {
                 ShortcutKeys = Keys.Control | Keys.R
             };
-            ToolStripMenuItem exitItem = new ToolStripMenuItem("Exit", null, (s, e) => Close());
+            ToolStripMenuItem exitItem = new ToolStripMenuItem(Language.GetString("$EXIT"), null, (s, e) => Close());
             fileMenu.DropDownItems.Add(saveItem);
             fileMenu.DropDownItems.Add(reloadItem);
             fileMenu.DropDownItems.Add(exitItem);
 
-            ToolStripMenuItem toolsMenu = new ToolStripMenuItem("Tools");
-            toolsMenu.DropDownItems.Add(new ToolStripMenuItem("Export XML", null, (s, e) => ExportXml()));
-            toolsMenu.DropDownItems.Add(new ToolStripMenuItem("Import XML", null, (s, e) => ImportXml()));
+            ToolStripMenuItem toolsMenu = new ToolStripMenuItem(Language.GetString("$TOOLS"));
+            toolsMenu.DropDownItems.Add(new ToolStripMenuItem(Language.GetString("$EXPORT_XML"), null, (s, e) => ExportXml()));
+            toolsMenu.DropDownItems.Add(new ToolStripMenuItem(Language.GetString("$IMPORT_XML"), null, (s, e) => ImportXml()));
 
             menu.Items.Add(fileMenu);
             menu.Items.Add(toolsMenu);
@@ -86,8 +87,8 @@ namespace Toolkit.Forms
             valueGrid.CellEndEdit += OnValueCellEdited;
 
             ContextMenuStrip gridMenu = new ContextMenuStrip();
-            gridMenu.Items.Add("Add key (duplicate selected)", null, (s, e) => DoKeyEdit(true));
-            gridMenu.Items.Add("Remove selected key", null, (s, e) => DoKeyEdit(false));
+            gridMenu.Items.Add(Language.GetString("$EFF_ADD_KEY"), null, (s, e) => DoKeyEdit(true));
+            gridMenu.Items.Add(Language.GetString("$EFF_REMOVE_KEY"), null, (s, e) => DoKeyEdit(false));
             gridMenu.Opening += (s, e) =>
             {
                 bool can = valueGrid.Tag is EffectParamInfo p && p.CanAddRemoveKeys;
@@ -366,19 +367,24 @@ namespace Toolkit.Forms
             }
         }
 
+        private string TitleText(bool edited)
+        {
+            return Language.GetString("$EFFECTS_EDITOR_TITLE") + " - " + effFile.Name + (edited ? "*" : "");
+        }
+
         private void SetEdited()
         {
             if (!isEdited)
             {
                 isEdited = true;
-                Text = "Effects Editor - " + effFile.Name + "*";
+                Text = TitleText(true);
             }
         }
 
         private void SetNotEdited()
         {
             isEdited = false;
-            Text = "Effects Editor - " + effFile.Name;
+            Text = TitleText(false);
         }
 
         private void OnFormClosing(object sender, FormClosingEventArgs e)
@@ -389,7 +395,7 @@ namespace Toolkit.Forms
             }
 
             DialogResult result = MessageBox.Show(
-                "Save changes to " + effFile.Name + "?", "Toolkit", MessageBoxButtons.YesNoCancel);
+                Language.GetString("$SAVE_PROMPT"), "Toolkit", MessageBoxButtons.YesNoCancel);
 
             if (result == DialogResult.Yes)
             {

--- a/Mafia2Libs/Forms/EffectsEditor.cs
+++ b/Mafia2Libs/Forms/EffectsEditor.cs
@@ -85,6 +85,16 @@ namespace Toolkit.Forms
             };
             valueGrid.CellEndEdit += OnValueCellEdited;
 
+            ContextMenuStrip gridMenu = new ContextMenuStrip();
+            gridMenu.Items.Add("Add key (duplicate selected)", null, (s, e) => DoKeyEdit(true));
+            gridMenu.Items.Add("Remove selected key", null, (s, e) => DoKeyEdit(false));
+            gridMenu.Opening += (s, e) =>
+            {
+                bool can = valueGrid.Tag is EffectParamInfo p && p.CanAddRemoveKeys;
+                foreach (ToolStripItem it in gridMenu.Items) it.Enabled = can;
+            };
+            valueGrid.ContextMenuStrip = gridMenu;
+
             // Right side: PropertyGrid on top, editable value grid below.
             SplitContainer rightSplit = new SplitContainer { Dock = DockStyle.Fill, Orientation = Orientation.Horizontal };
             rightSplit.Panel1.Controls.Add(propertyGrid);
@@ -266,6 +276,42 @@ namespace Toolkit.Forms
 
             effects.PatchFloat(offset, value);
             SetEdited();
+        }
+
+        private void DoKeyEdit(bool add)
+        {
+            if (!(valueGrid.Tag is EffectParamInfo p) || !p.CanAddRemoveKeys) return;
+            int row = valueGrid.CurrentCell != null ? valueGrid.CurrentCell.RowIndex : 0;
+            if (row < 0) row = 0;
+
+            System.Collections.Generic.List<int> path = GetNodePath(treeChunks.SelectedNode);
+            bool ok = add ? effects.AddKeyframe(p, row) : effects.RemoveKeyframe(p, row);
+            if (!ok) return;
+
+            SetEdited();
+            BuildTree();          // structural change shifts offsets -> reparse + rebuild
+            SelectNodePath(path); // restore selection so the grid shows the updated keys
+        }
+
+        private static System.Collections.Generic.List<int> GetNodePath(TreeNode node)
+        {
+            System.Collections.Generic.List<int> path = new System.Collections.Generic.List<int>();
+            while (node != null) { path.Insert(0, node.Index); node = node.Parent; }
+            return path;
+        }
+
+        private void SelectNodePath(System.Collections.Generic.List<int> path)
+        {
+            if (path == null || path.Count == 0) return;
+            TreeNodeCollection nodes = treeChunks.Nodes;
+            TreeNode cur = null;
+            foreach (int idx in path)
+            {
+                if (idx < 0 || idx >= nodes.Count) return;
+                cur = nodes[idx];
+                nodes = cur.Nodes;
+            }
+            if (cur != null) { cur.EnsureVisible(); treeChunks.SelectedNode = cur; }
         }
 
         private void RestoreCell(EffectParamInfo p, int row, int col)

--- a/Mafia2Libs/Forms/EffectsEditor.cs
+++ b/Mafia2Libs/Forms/EffectsEditor.cs
@@ -1,0 +1,358 @@
+using ResourceTypes.Effects;
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace Toolkit.Forms
+{
+    /// <summary>
+    /// Lightweight viewer/editor for ".eff" (SDS "Effects") files. Presents the generic
+    /// chunk tree (tag/size/payload) in a TreeView with a PropertyGrid for the selected chunk,
+    /// and supports XML export/import plus saving back to the binary .eff.
+    ///
+    /// Built entirely in code (no designer/resx) to keep the new format self-contained.
+    /// </summary>
+    public class EffectsEditor : Form
+    {
+        private readonly FileInfo effFile;
+        private EffectsFile effects;
+
+        private TreeView treeChunks;
+        private PropertyGrid propertyGrid;
+        private DataGridView valueGrid;
+        private SaveFileDialog saveDialog;
+        private OpenFileDialog openDialog;
+
+        private bool isEdited;
+
+        public EffectsEditor(FileInfo file)
+        {
+            effFile = file;
+            BuildUi();
+            LoadData();
+            Show();
+        }
+
+        private void BuildUi()
+        {
+            Text = "Effects Editor - " + effFile.Name;
+            ClientSize = new System.Drawing.Size(900, 560);
+            KeyPreview = true;
+
+            MenuStrip menu = new MenuStrip();
+
+            ToolStripMenuItem fileMenu = new ToolStripMenuItem("File");
+            ToolStripMenuItem saveItem = new ToolStripMenuItem("Save", null, (s, e) => Save())
+            {
+                ShortcutKeys = Keys.Control | Keys.S
+            };
+            ToolStripMenuItem reloadItem = new ToolStripMenuItem("Reload", null, (s, e) => Reload())
+            {
+                ShortcutKeys = Keys.Control | Keys.R
+            };
+            ToolStripMenuItem exitItem = new ToolStripMenuItem("Exit", null, (s, e) => Close());
+            fileMenu.DropDownItems.Add(saveItem);
+            fileMenu.DropDownItems.Add(reloadItem);
+            fileMenu.DropDownItems.Add(exitItem);
+
+            ToolStripMenuItem toolsMenu = new ToolStripMenuItem("Tools");
+            toolsMenu.DropDownItems.Add(new ToolStripMenuItem("Export XML", null, (s, e) => ExportXml()));
+            toolsMenu.DropDownItems.Add(new ToolStripMenuItem("Import XML", null, (s, e) => ImportXml()));
+
+            menu.Items.Add(fileMenu);
+            menu.Items.Add(toolsMenu);
+
+            SplitContainer split = new SplitContainer
+            {
+                Dock = DockStyle.Fill,
+                SplitterDistance = 430
+            };
+
+            treeChunks = new TreeView { Dock = DockStyle.Fill, HideSelection = false };
+            treeChunks.AfterSelect += OnNodeSelected;
+
+            propertyGrid = new PropertyGrid { Dock = DockStyle.Fill };
+            propertyGrid.PropertyValueChanged += OnPropertyValueChanged;
+
+            valueGrid = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                AllowUserToAddRows = false,
+                AllowUserToDeleteRows = false,
+                RowHeadersVisible = false,
+                AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
+                Visible = false
+            };
+            valueGrid.CellEndEdit += OnValueCellEdited;
+
+            // Right side: PropertyGrid on top, editable value grid below.
+            SplitContainer rightSplit = new SplitContainer { Dock = DockStyle.Fill, Orientation = Orientation.Horizontal };
+            rightSplit.Panel1.Controls.Add(propertyGrid);
+            rightSplit.Panel2.Controls.Add(valueGrid);
+
+            split.Panel1.Controls.Add(treeChunks);
+            split.Panel2.Controls.Add(rightSplit);
+
+            Controls.Add(split);
+            Controls.Add(menu);
+            MainMenuStrip = menu;
+
+            saveDialog = new SaveFileDialog { DefaultExt = "xml", Filter = "XML|*.xml" };
+            openDialog = new OpenFileDialog { DefaultExt = "xml", Filter = "XML|*.xml" };
+
+            FormClosing += OnFormClosing;
+        }
+
+        private void LoadData()
+        {
+            effects = new EffectsFile();
+            effects.ReadFromFile(effFile.FullName);
+            BuildTree();
+            SetNotEdited();
+        }
+
+        private void BuildTree()
+        {
+            treeChunks.BeginUpdate();
+            treeChunks.Nodes.Clear();
+            propertyGrid.SelectedObject = null;
+
+            if (effects.IsRawFallback)
+            {
+                TreeNode rawNode = new TreeNode("Unparsed (raw passthrough) - " + effects.RawFallback.Length + " bytes");
+                treeChunks.Nodes.Add(rawNode);
+            }
+            else
+            {
+                // Readable summary: one node per effect, named by its generation(s) and classified by operators.
+                System.Collections.Generic.List<EffectPatternInfo> summary = effects.GetSummary();
+                if (summary.Count > 0)
+                {
+                    TreeNode effectsRoot = new TreeNode("Effects (" + summary.Count + ")");
+                    foreach (EffectPatternInfo effect in summary)
+                    {
+                        TreeNode effectNode = new TreeNode(effect.ToString()) { Tag = effect };
+                        foreach (EffectFrameInfo frame in effect.Frames)
+                        {
+                            effectNode.Nodes.Add(new TreeNode(frame.ToString()) { Tag = frame });
+                        }
+                        foreach (EffectSoundInfo snd in effect.Sounds)
+                        {
+                            effectNode.Nodes.Add(new TreeNode(snd.ToString()) { Tag = snd });
+                        }
+                        foreach (EffectGenerationInfo gen in effect.Generations)
+                        {
+                            TreeNode genNode = new TreeNode(gen.ToString()) { Tag = gen };
+                            foreach (EffectOperatorInfo op in gen.Operators)
+                            {
+                                TreeNode opNode = new TreeNode(op.ToString()) { Tag = op };
+                                foreach (EffectParamInfo p in op.Parameters)
+                                {
+                                    opNode.Nodes.Add(new TreeNode(p.ToString()) { Tag = p });
+                                }
+                                genNode.Nodes.Add(opNode);
+                            }
+                            effectNode.Nodes.Add(genNode);
+                        }
+                        effectsRoot.Nodes.Add(effectNode);
+                    }
+                    treeChunks.Nodes.Add(effectsRoot);
+                }
+
+                // Raw chunk tree for power users / round-trip editing.
+                TreeNode rawRoot = new TreeNode("Raw chunks");
+                foreach (EffectChunk root in effects.Roots)
+                {
+                    rawRoot.Nodes.Add(BuildNode(root));
+                }
+                treeChunks.Nodes.Add(rawRoot);
+            }
+
+            treeChunks.EndUpdate();
+            if (treeChunks.Nodes.Count > 0)
+            {
+                treeChunks.Nodes[0].Expand();
+            }
+        }
+
+        private static TreeNode BuildNode(EffectChunk chunk)
+        {
+            TreeNode node = new TreeNode(chunk.ToString()) { Tag = chunk };
+            if (chunk.Children != null)
+            {
+                foreach (EffectChunk child in chunk.Children)
+                {
+                    node.Nodes.Add(BuildNode(child));
+                }
+            }
+            return node;
+        }
+
+        private void OnNodeSelected(object sender, TreeViewEventArgs e)
+        {
+            object tag = e.Node?.Tag;
+            propertyGrid.SelectedObject = tag;
+            PopulateValueGrid(tag as EffectParamInfo);
+        }
+
+        private void PopulateValueGrid(EffectParamInfo p)
+        {
+            valueGrid.Tag = null;
+            valueGrid.Rows.Clear();
+            valueGrid.Columns.Clear();
+
+            bool hasScalars = p != null && p.Scalars != null && p.Scalars.Length > 0 && p.ScalarOffset >= 0;
+            bool hasKeys = p != null && p.Keys != null && p.Keys.Count > 0 && p.KeyOffsets != null;
+            if (!hasScalars && !hasKeys)
+            {
+                valueGrid.Visible = false;
+                return;
+            }
+
+            if (hasScalars)
+            {
+                valueGrid.Columns.Add("v", "Value");
+                foreach (float f in p.Scalars)
+                {
+                    valueGrid.Rows.Add(f.ToString("0.######", System.Globalization.CultureInfo.InvariantCulture));
+                }
+            }
+            else
+            {
+                int cols = 0;
+                foreach (float[] k in p.Keys) cols = System.Math.Max(cols, k.Length);
+                valueGrid.Columns.Add("t", "Time");
+                for (int c = 1; c < cols; c++) valueGrid.Columns.Add("v" + c, "Value " + c);
+                foreach (float[] k in p.Keys)
+                {
+                    string[] cells = new string[cols];
+                    for (int c = 0; c < cols; c++)
+                        cells[c] = c < k.Length ? k[c].ToString("0.######", System.Globalization.CultureInfo.InvariantCulture) : "";
+                    valueGrid.Rows.Add(cells);
+                }
+            }
+
+            valueGrid.Tag = p;
+            valueGrid.Visible = true;
+        }
+
+        private void OnValueCellEdited(object sender, DataGridViewCellEventArgs e)
+        {
+            if (!(valueGrid.Tag is EffectParamInfo p)) return;
+            object cell = valueGrid.Rows[e.RowIndex].Cells[e.ColumnIndex].Value;
+            if (!float.TryParse(cell?.ToString(), System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture, out float value))
+            {
+                // restore displayed value on bad input
+                RestoreCell(p, e.RowIndex, e.ColumnIndex);
+                return;
+            }
+
+            int offset;
+            if (p.ScalarOffset >= 0 && p.Scalars != null)
+            {
+                if (e.RowIndex >= p.Scalars.Length) return;
+                offset = p.ScalarOffset + e.RowIndex * 4;
+                p.Scalars[e.RowIndex] = value;
+            }
+            else if (p.KeyOffsets != null && e.RowIndex < p.KeyOffsets.Count)
+            {
+                float[] key = p.Keys[e.RowIndex];
+                if (e.ColumnIndex >= key.Length) { RestoreCell(p, e.RowIndex, e.ColumnIndex); return; }
+                offset = p.KeyOffsets[e.RowIndex] + e.ColumnIndex * 4;
+                key[e.ColumnIndex] = value;
+            }
+            else return;
+
+            effects.PatchFloat(offset, value);
+            SetEdited();
+        }
+
+        private void RestoreCell(EffectParamInfo p, int row, int col)
+        {
+            float? v = null;
+            if (p.Scalars != null && row < p.Scalars.Length) v = p.Scalars[row];
+            else if (p.Keys != null && row < p.Keys.Count && col < p.Keys[row].Length) v = p.Keys[row][col];
+            if (v.HasValue)
+                valueGrid.Rows[row].Cells[col].Value = v.Value.ToString("0.######", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        private void OnPropertyValueChanged(object sender, PropertyValueChangedEventArgs e)
+        {
+            SetEdited();
+
+            // Refresh the label of the edited node (tag/size may have changed).
+            TreeNode selected = treeChunks.SelectedNode;
+            if (selected?.Tag is EffectChunk chunk)
+            {
+                selected.Text = chunk.ToString();
+            }
+        }
+
+        private void Save()
+        {
+            // Keep a backup, matching the convention used by the other editors.
+            File.Copy(effFile.FullName, effFile.FullName + "_old", true);
+            effects.WriteToFile(effFile.FullName);
+            SetNotEdited();
+        }
+
+        private void Reload()
+        {
+            LoadData();
+        }
+
+        private void ExportXml()
+        {
+            if (saveDialog.ShowDialog() == DialogResult.OK)
+            {
+                effects.ConvertToXML(saveDialog.FileName);
+            }
+        }
+
+        private void ImportXml()
+        {
+            if (openDialog.ShowDialog() == DialogResult.OK && File.Exists(openDialog.FileName))
+            {
+                effects.ConvertFromXML(openDialog.FileName);
+                BuildTree();
+                SetEdited();
+            }
+        }
+
+        private void SetEdited()
+        {
+            if (!isEdited)
+            {
+                isEdited = true;
+                Text = "Effects Editor - " + effFile.Name + "*";
+            }
+        }
+
+        private void SetNotEdited()
+        {
+            isEdited = false;
+            Text = "Effects Editor - " + effFile.Name;
+        }
+
+        private void OnFormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (!isEdited)
+            {
+                return;
+            }
+
+            DialogResult result = MessageBox.Show(
+                "Save changes to " + effFile.Name + "?", "Toolkit", MessageBoxButtons.YesNoCancel);
+
+            if (result == DialogResult.Yes)
+            {
+                Save();
+            }
+            else if (result == DialogResult.Cancel)
+            {
+                e.Cancel = true;
+            }
+        }
+    }
+}

--- a/Mafia2Libs/Localisations/ar_AR.xml
+++ b/Mafia2Libs/Localisations/ar_AR.xml
@@ -485,4 +485,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/cz_CZ.xml
+++ b/Mafia2Libs/Localisations/cz_CZ.xml
@@ -501,4 +501,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/en_gb.xml
+++ b/Mafia2Libs/Localisations/en_gb.xml
@@ -486,4 +486,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/fr_FR.xml
+++ b/Mafia2Libs/Localisations/fr_FR.xml
@@ -492,4 +492,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Éditeur d'effets</String>
+	<String ID="$EFF_ADD_KEY">Ajouter une clé (dupliquer la sélection)</String>
+	<String ID="$EFF_REMOVE_KEY">Supprimer la clé sélectionnée</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/pl_PL.xml
+++ b/Mafia2Libs/Localisations/pl_PL.xml
@@ -501,4 +501,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/ru_RU.xml
+++ b/Mafia2Libs/Localisations/ru_RU.xml
@@ -463,4 +463,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/Localisations/sk_SK.xml
+++ b/Mafia2Libs/Localisations/sk_SK.xml
@@ -497,4 +497,8 @@
 	<String ID="$TEST_CONVERT_32BIT">Test Convert 32-bit</String>
 	<String ID="$XBIN_EDITOR">XBin Editor</String>
 
+	<!-- Effects Editor Strings -->
+	<String ID="$EFFECTS_EDITOR_TITLE">Effects Editor</String>
+	<String ID="$EFF_ADD_KEY">Add key (duplicate selected)</String>
+	<String ID="$EFF_REMOVE_KEY">Remove selected key</String>
 </Localisation>

--- a/Mafia2Libs/MCP/Tools/EffectsTools.cs
+++ b/Mafia2Libs/MCP/Tools/EffectsTools.cs
@@ -1,0 +1,138 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+using ResourceTypes.Effects;
+
+namespace Mafia2Tool.MCP.Tools;
+
+/// <summary>
+/// MCP tools for parsing Mafia II ".eff" files (the SDS "Effects" resource): the effect
+/// (pattern) list with names/kinds, and per-effect generations, operators and parameters.
+/// </summary>
+[McpServerToolType]
+public class EffectsTools
+{
+    [McpServerTool(Name = "parse_effects_file"), Description("Parse a Mafia II .eff (Effects) file. Returns the effect list, or full detail for one effect when effectIndex is set.")]
+    public string ParseEffectsFile(
+        [Description("Full path to the .eff file")] string filePath,
+        [Description("Index of a single effect to return in full detail (default: -1 = list all)")] int effectIndex = -1)
+    {
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                return JsonSerializer.Serialize(new { success = false, error = "File not found: " + filePath });
+            }
+
+            var eff = new EffectsFile();
+            eff.ReadFromFile(filePath);
+            return BuildJson(eff, effectIndex);
+        }
+        catch (Exception ex)
+        {
+            return McpError.FailJson(ex);
+        }
+    }
+
+    [McpServerTool(Name = "parse_effects_from_bytes"), Description("Parse .eff (Effects) content from base64 bytes (e.g. the output of extract_resource on an 'Effects' resource).")]
+    public string ParseEffectsFromBytes(
+        [Description("Base64-encoded .eff bytes")] string base64Data,
+        [Description("Index of a single effect to return in full detail (default: -1 = list all)")] int effectIndex = -1)
+    {
+        try
+        {
+            var bytes = Convert.FromBase64String(base64Data);
+            var eff = new EffectsFile();
+            eff.ReadFromBytes(bytes);
+            return BuildJson(eff, effectIndex);
+        }
+        catch (Exception ex)
+        {
+            return McpError.FailJson(ex);
+        }
+    }
+
+    private static string BuildJson(EffectsFile eff, int effectIndex)
+    {
+        var summary = eff.GetSummary();
+
+        if (eff.IsRawFallback)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                rawFallback = true,
+                note = "File could not be parsed losslessly; treated as opaque.",
+                effectCount = 0
+            });
+        }
+
+        if (effectIndex >= 0)
+        {
+            if (effectIndex >= summary.Count)
+            {
+                return JsonSerializer.Serialize(new { success = false, error = "effectIndex out of range (0.." + (summary.Count - 1) + ")" });
+            }
+            return JsonSerializer.Serialize(new
+            {
+                success = true,
+                effectCount = summary.Count,
+                effect = FullEffect(summary[effectIndex], effectIndex)
+            });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            success = true,
+            effectCount = summary.Count,
+            effects = summary.Select((e, i) => new
+            {
+                index = i,
+                id = e.Id,
+                name = e.DisplayName,
+                kind = e.Kind,
+                generations = e.GenerationCount,
+                frames = e.FrameCount,
+                sounds = e.SoundCount,
+                generationNames = e.Generations.Select(g => g.Name).ToList(),
+                operators = e.Generations.SelectMany(g => g.Operators.Select(o => o.Type ?? ("Operator" + o.TypeId)))
+                                          .Distinct().ToList()
+            }).ToList()
+        });
+    }
+
+    private static object FullEffect(EffectPatternInfo e, int index)
+    {
+        return new
+        {
+            index,
+            id = e.Id,
+            name = e.DisplayName,
+            kind = e.Kind,
+            generations = e.Generations.Select(g => new
+            {
+                name = g.Name,
+                operators = g.Operators.Select(o => new
+                {
+                    type = o.Type ?? ("Operator" + o.TypeId),
+                    typeId = o.TypeId,
+                    enabled = o.Enabled,
+                    parameters = o.Parameters.Select(p => new
+                    {
+                        tag = p.Tag,
+                        name = p.Name,
+                        animated = p.IsAnimated,
+                        keyCount = p.KeyCount,
+                        summary = p.Summary,
+                        values = p.Values
+                    }).ToList()
+                }).ToList()
+            }).ToList(),
+            frames = e.Frames.Select(f => new { type = f.TypeName, classId = f.ClassId, position = f.Transform }).ToList(),
+            soundElements = e.Sounds.Select(s => s.Name).ToList()
+        };
+    }
+}

--- a/Mafia2Libs/MCP/Tools/UtilityTools.cs
+++ b/Mafia2Libs/MCP/Tools/UtilityTools.cs
@@ -406,6 +406,10 @@ public class UtilityTools
         if (magic32 == 0x35425346)
             return ("FSB", "FMOD Sound Bank", "Mafia II", "High");
 
+        // .eff Effects library: root chunk tag is 666 (0x29A) = C_EffectsLibrary.
+        if (magic32 == 0x29A)
+            return ("Effects", "Effects (.eff) particle/FX library", "Mafia II/DE", "High");
+
         if (extension.Equals(".xbin", StringComparison.OrdinalIgnoreCase))
             return ("XBin", "XBin Data Container", "Mafia III/I:DE", "Medium");
 
@@ -420,6 +424,9 @@ public class UtilityTools
 
         if (extension.Equals(".cut", StringComparison.OrdinalIgnoreCase))
             return ("Cutscene", "Cutscene Animation", "Mafia II/DE", "Medium");
+
+        if (extension.Equals(".eff", StringComparison.OrdinalIgnoreCase))
+            return ("Effects", "Effects (.eff) particle/FX library", "Mafia II/DE", "Medium");
 
         return ("Unknown", "Unknown format", "Unknown", "Low");
     }

--- a/Mafia2Libs/ResourceTypes/FileTypes/Effects/EffectsFile.cs
+++ b/Mafia2Libs/ResourceTypes/FileTypes/Effects/EffectsFile.cs
@@ -428,6 +428,16 @@ namespace ResourceTypes.Effects
         [Browsable(false)] public int ScalarOffset { get; set; } = -1;          // first scalar float
         [Browsable(false)] public List<int> KeyOffsets { get; set; }            // start of each key's floats
 
+        // For keyframe add/remove (only set when the displayed keys form one simple [123] curve).
+        [Browsable(false)] public int CurveHeaderOffset { get; set; } = -1;     // header of the innermost [123]
+        [Browsable(false)] public int KeyCountOffset { get; set; } = -1;        // u32 key count in the [123] body
+        [Browsable(false)] public List<int> KeyChunkLengths { get; set; }       // full [124] chunk size per key
+        [Browsable(false)] public bool MultiCurve { get; set; }                 // keys span >1 inner curve -> no add/remove
+
+        [Browsable(false)]
+        public bool CanAddRemoveKeys =>
+            !MultiCurve && CurveHeaderOffset >= 0 && KeyCountOffset >= 0 && KeyChunkLengths != null && KeyOffsets != null;
+
         [Category("Parameter")]
         public int KeyCount => Keys?.Count ?? 0;
 
@@ -804,7 +814,8 @@ namespace ResourceTypes.Effects
                 param.IsAnimated = true;
                 param.Keys = new List<float[]>();
                 param.KeyOffsets = new List<int>();
-                CollectKeys(eff, curveStart, curveLen, param.Keys, param.KeyOffsets);
+                param.KeyChunkLengths = new List<int>();
+                CollectKeys(eff, curveStart, curveLen, param);
                 return param;
             }
 
@@ -837,7 +848,7 @@ namespace ResourceTypes.Effects
         }
 
         /// <summary>Recursively gather innermost keyframes; each [124] leaf payload yields its leading floats as [time, value...].</summary>
-        private static void CollectKeys(byte[] eff, int start, int length, List<float[]> keys, List<int> offsets)
+        private static void CollectKeys(byte[] eff, int start, int length, EffectParamInfo param)
         {
             // [123] body = u32 keyCount prefix, then [124] keys.
             foreach (int pre in new[] { 4, 0 })
@@ -846,6 +857,7 @@ namespace ResourceTypes.Effects
                 var spans = Tile(eff, start + pre, length - pre);
                 if (spans.Count == 0) continue;
 
+                bool leafCurveHere = false;
                 foreach (var key in spans)
                 {
                     if (key.Tag != CurveKeyTag) continue;
@@ -854,17 +866,41 @@ namespace ResourceTypes.Effects
                     int innerStart, innerLen;
                     if (FindCurve(eff, key.Start, key.Length, out innerStart, out innerLen))
                     {
-                        CollectKeys(eff, innerStart, innerLen, keys, offsets);
+                        CollectKeys(eff, innerStart, innerLen, param);
                     }
                     else
                     {
                         float[] f = ReadFloats(eff, key.Start, Math.Min(key.Length, 20)); // time + up to 4 values
-                        if (f.Length > 0) { keys.Add(f); offsets.Add(key.Start); }
+                        if (f.Length > 0)
+                        {
+                            param.Keys.Add(f);
+                            param.KeyOffsets.Add(key.Start);
+                            param.KeyChunkLengths.Add(key.Length + HeaderSize); // full [124] chunk size
+                            leafCurveHere = true;
+                        }
                     }
                 }
-                if (keys.Count > 0) return;
+
+                if (leafCurveHere)
+                {
+                    // This [123] directly holds float keys -> it's the editable curve.
+                    int curveHeader = start - HeaderSize;
+                    if (param.CurveHeaderOffset < 0)
+                    {
+                        param.CurveHeaderOffset = curveHeader;
+                        param.KeyCountOffset = (pre == 4) ? start : -1;
+                    }
+                    else if (param.CurveHeaderOffset != curveHeader)
+                    {
+                        param.MultiCurve = true; // keys span multiple curves -> disable add/remove
+                    }
+                }
+
+                if (param.Keys.Count > 0) return;
             }
         }
+
+        private const int HeaderSize = EffectChunk.HeaderSize;
 
         private static float[] ReadFloats(byte[] eff, int start, int length)
         {
@@ -1020,6 +1056,112 @@ namespace ResourceTypes.Effects
             byte[] bytes = BitConverter.GetBytes(value);
             Array.Copy(bytes, 0, _editBuffer, offset, 4);
             TypedEdited = true;
+        }
+
+        /// <summary>Insert a keyframe by duplicating key <paramref name="keyIndex"/> of a simple curve param.</summary>
+        public bool AddKeyframe(EffectParamInfo p, int keyIndex)
+        {
+            if (p == null || !p.CanAddRemoveKeys) return false;
+            if (keyIndex < 0 || keyIndex >= p.KeyOffsets.Count) return false;
+            if (_editBuffer == null) _editBuffer = BuildBytes();
+            int keyStart = p.KeyOffsets[keyIndex] - EffectChunk.HeaderSize;
+            return Splice(p, keyStart, p.KeyChunkLengths[keyIndex], true);
+        }
+
+        /// <summary>Delete keyframe <paramref name="keyIndex"/> from a simple curve param (keeps at least one).</summary>
+        public bool RemoveKeyframe(EffectParamInfo p, int keyIndex)
+        {
+            if (p == null || !p.CanAddRemoveKeys) return false;
+            if (keyIndex < 0 || keyIndex >= p.KeyOffsets.Count || p.KeyOffsets.Count <= 1) return false;
+            if (_editBuffer == null) _editBuffer = BuildBytes();
+            int keyStart = p.KeyOffsets[keyIndex] - EffectChunk.HeaderSize;
+            return Splice(p, keyStart, p.KeyChunkLengths[keyIndex], false);
+        }
+
+        // Insert (duplicate) or remove a [124] key chunk at keyChunkStart, fixing the [123] key count and
+        // every enclosing chunk's size. All adjusted fields sit before the edit point, so offsets stay valid.
+        private bool Splice(EffectParamInfo p, int keyChunkStart, int keyChunkLen, bool insert)
+        {
+            List<int> chain = WalkToOffset(_editBuffer, p.CurveHeaderOffset);
+            if (chain == null) return false;
+
+            byte[] nb;
+            int delta;
+            if (insert)
+            {
+                int insertPos = keyChunkStart + keyChunkLen;
+                nb = new byte[_editBuffer.Length + keyChunkLen];
+                Array.Copy(_editBuffer, 0, nb, 0, insertPos);
+                Array.Copy(_editBuffer, keyChunkStart, nb, insertPos, keyChunkLen);     // duplicated key bytes
+                Array.Copy(_editBuffer, insertPos, nb, insertPos + keyChunkLen, _editBuffer.Length - insertPos);
+                delta = keyChunkLen;
+            }
+            else
+            {
+                nb = new byte[_editBuffer.Length - keyChunkLen];
+                Array.Copy(_editBuffer, 0, nb, 0, keyChunkStart);
+                Array.Copy(_editBuffer, keyChunkStart + keyChunkLen, nb, keyChunkStart, _editBuffer.Length - keyChunkStart - keyChunkLen);
+                delta = -keyChunkLen;
+            }
+
+            if (p.KeyCountOffset >= 0)
+            {
+                uint kc = BitConverter.ToUInt32(nb, p.KeyCountOffset);
+                Array.Copy(BitConverter.GetBytes((uint)(kc + (insert ? 1 : -1))), 0, nb, p.KeyCountOffset, 4);
+            }
+
+            foreach (int sizeOff in chain)
+            {
+                uint sz = BitConverter.ToUInt32(nb, sizeOff);
+                Array.Copy(BitConverter.GetBytes((uint)(sz + delta)), 0, nb, sizeOff, 4);
+            }
+
+            _editBuffer = nb;
+            TypedEdited = true;
+            return true;
+        }
+
+        /// <summary>Walk from the buffer root down to the chunk whose header is at targetHeader; returns the
+        /// size-field offsets of every chunk on that path (root..target inclusive).</summary>
+        private static List<int> WalkToOffset(byte[] buf, int targetHeader)
+        {
+            List<int> chain = new List<int>();
+            int pStart = 0, pEnd = buf.Length;
+            int guard = 0;
+            while (guard++ < 64)
+            {
+                int childHeader = FindChildContaining(buf, pStart, pEnd, targetHeader);
+                if (childHeader < 0) return null;
+                chain.Add(childHeader + 4);
+                if (childHeader == targetHeader) return chain;
+                uint size = BitConverter.ToUInt32(buf, childHeader + 4);
+                pStart = childHeader + 8;
+                pEnd = childHeader + (int)size;
+            }
+            return null;
+        }
+
+        // Prefix-aware: find the child chunk (within [pStart,pEnd)) whose byte range contains target.
+        private static int FindChildContaining(byte[] buf, int pStart, int pEnd, int target)
+        {
+            foreach (int pre in new[] { 0, 4, 5, 8, 12, 16, 20, 24 })
+            {
+                int s = pStart + pre;
+                if (s > pEnd) break;
+                int i = s;
+                bool ok = true;
+                int found = -1;
+                while (i < pEnd)
+                {
+                    if (pEnd - i < 8) { ok = false; break; }
+                    uint sz = BitConverter.ToUInt32(buf, i + 4);
+                    if (sz < 8 || i + (long)sz > pEnd) { ok = false; break; }
+                    if (target >= i && target < i + (int)sz) found = i;
+                    i += (int)sz;
+                }
+                if (ok && i == pEnd && found >= 0) return found;
+            }
+            return -1;
         }
 
         private byte[] BuildBytes()

--- a/Mafia2Libs/ResourceTypes/FileTypes/Effects/EffectsFile.cs
+++ b/Mafia2Libs/ResourceTypes/FileTypes/Effects/EffectsFile.cs
@@ -1,0 +1,1141 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+
+namespace ResourceTypes.Effects
+{
+    /// <summary>
+    /// Reader/writer for the Mafia II ".eff" file — the payload of an SDS "Effects" resource.
+    ///
+    /// Format (little-endian), reverse-engineered from the game's
+    /// ue::sys::utils::C_InputChunk reader and ue::gfx::effects::C_EffectsLibrary::Load:
+    ///
+    ///   chunk := u32 tag, u32 size, byte[size - 8] payload
+    ///
+    ///   * 'size' INCLUDES the 8-byte header. The minimum legal size is 8 (an empty chunk);
+    ///     0xFFFFFFFF is explicitly rejected by C_InputChunk::Ascend.
+    ///   * A *container* chunk's payload is a sequence of child chunks packed back-to-back
+    ///     that fills the payload exactly. There is NO padding/alignment between chunks.
+    ///   * A *leaf* chunk's payload is raw field data (ints/floats/strings/vectors...).
+    ///   * The root chunk uses tag 666 (C_EffectsLibrary). Every other tag is a
+    ///     context-local enumeration (e.g. inside a pattern: 1=frames, 2=generations, 3..11
+    ///     are scalar params, default=sounds; an operator uses 300/350). Because a tag's
+    ///     meaning depends on its parent, this reader keeps the generic (tag, payload/children)
+    ///     tree rather than hard-coding semantics.
+    ///
+    /// This class never mutates bytes it does not understand: after parsing it re-serializes
+    /// and compares to the original, falling back to a verbatim passthrough on any mismatch.
+    /// </summary>
+    public class EffectChunk
+    {
+        public const uint InvalidSize = 0xFFFFFFFF;
+        public const int HeaderSize = 8;
+
+        /// <summary>Tag of the chunk that stores an operator's E_OperatorType id (C_Operator::Load, 0x12C).</summary>
+        public const uint OperatorTypeTag = 300;
+
+        [Category("Chunk"), Description("32-bit chunk tag/id. Meaning is relative to the parent chunk.")]
+        public uint Tag { get; set; }
+
+        /// <summary>Child chunks when this is a container; null for a leaf.</summary>
+        [Browsable(false)]
+        public List<EffectChunk> Children { get; set; }
+
+        /// <summary>Raw payload bytes when this is a leaf; null for a container.</summary>
+        [Browsable(false)]
+        public byte[] Data { get; set; }
+
+        [Category("Chunk"), Description("True when this chunk holds child chunks rather than raw data.")]
+        public bool IsContainer => Children != null;
+
+        [Category("Chunk"), Description("Number of immediate child chunks.")]
+        public int ChildCount => Children?.Count ?? 0;
+
+        [Category("Chunk"), Description("Total on-disk size in bytes, including the 8-byte header.")]
+        public uint Size => (uint)(HeaderSize + GetPayloadLength());
+
+        [Category("Chunk"), Description("If this is an operator-type chunk (tag 300), the decoded E_OperatorType name.")]
+        public string OperatorType
+        {
+            get
+            {
+                if (Tag == OperatorTypeTag && Data != null && Data.Length >= 4)
+                {
+                    return EffectsOperatorTypes.Lookup(BitConverter.ToUInt32(Data, 0));
+                }
+                return null;
+            }
+        }
+
+        [Category("Chunk"), Description("Leaf payload reinterpreted as 32-bit floats (read-only view).")]
+        public string DataFloats
+        {
+            get
+            {
+                if (Data == null || Data.Length == 0 || (Data.Length & 3) != 0)
+                {
+                    return string.Empty;
+                }
+
+                int count = Data.Length / 4;
+                string[] parts = new string[count];
+                for (int i = 0; i < count; i++)
+                {
+                    parts[i] = BitConverter.ToSingle(Data, i * 4).ToString("0.######", CultureInfo.InvariantCulture);
+                }
+                return string.Join(", ", parts);
+            }
+        }
+
+        [Category("Chunk"), Description("Leaf payload reinterpreted as 32-bit signed integers (read-only view).")]
+        public string DataInts
+        {
+            get
+            {
+                if (Data == null || Data.Length == 0 || (Data.Length & 3) != 0)
+                {
+                    return string.Empty;
+                }
+
+                int count = Data.Length / 4;
+                string[] parts = new string[count];
+                for (int i = 0; i < count; i++)
+                {
+                    parts[i] = BitConverter.ToInt32(Data, i * 4).ToString(CultureInfo.InvariantCulture);
+                }
+                return string.Join(", ", parts);
+            }
+        }
+
+        [Category("Chunk"), Description("Leaf payload as a hex string. Editable for leaf chunks only.")]
+        public string DataHex
+        {
+            get { return Data == null ? string.Empty : Convert.ToHexString(Data); }
+            set
+            {
+                if (Children != null)
+                {
+                    // Containers derive their bytes from children; ignore manual edits.
+                    return;
+                }
+
+                Data = string.IsNullOrWhiteSpace(value)
+                    ? Array.Empty<byte>()
+                    : Convert.FromHexString(value.Trim());
+            }
+        }
+
+        public EffectChunk() { }
+
+        public EffectChunk(uint tag)
+        {
+            Tag = tag;
+            Data = Array.Empty<byte>();
+        }
+
+        private int GetPayloadLength()
+        {
+            if (Children != null)
+            {
+                int total = 0;
+                foreach (EffectChunk child in Children)
+                {
+                    total += (int)child.Size;
+                }
+                return total;
+            }
+
+            return Data?.Length ?? 0;
+        }
+
+        public static EffectChunk Read(BinaryReader reader)
+        {
+            long start = reader.BaseStream.Position;
+            uint tag = reader.ReadUInt32();
+            uint size = reader.ReadUInt32();
+
+            if (size == InvalidSize || size < HeaderSize)
+            {
+                throw new InvalidDataException(
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Invalid .eff chunk size {0} at offset {1} (tag {2}).", size, start, tag));
+            }
+
+            int payloadLength = (int)(size - HeaderSize);
+            byte[] payload = reader.ReadBytes(payloadLength);
+            if (payload.Length != payloadLength)
+            {
+                throw new EndOfStreamException(
+                    string.Format(CultureInfo.InvariantCulture,
+                        "Truncated .eff chunk at offset {0} (tag {1}).", start, tag));
+            }
+
+            EffectChunk chunk = new EffectChunk { Tag = tag };
+            if (TryParseChildren(payload, out List<EffectChunk> children))
+            {
+                chunk.Children = children;
+            }
+            else
+            {
+                chunk.Data = payload;
+            }
+
+            return chunk;
+        }
+
+        /// <summary>
+        /// Tries to interpret <paramref name="payload"/> as a contiguous run of child chunks.
+        /// Succeeds only when the children tile the payload exactly (no leftover, no overrun),
+        /// which is how the game stores container chunks. Round-trip correctness does not rely
+        /// on this being semantically perfect: a leaf misread as a container still re-serializes
+        /// to identical bytes because there is no padding.
+        /// </summary>
+        private static bool TryParseChildren(byte[] payload, out List<EffectChunk> children)
+        {
+            children = null;
+            if (payload.Length < HeaderSize)
+            {
+                return false;
+            }
+
+            List<EffectChunk> result = new List<EffectChunk>();
+            using (MemoryStream ms = new MemoryStream(payload, false))
+            using (BinaryReader reader = new BinaryReader(ms))
+            {
+                while (ms.Position < payload.Length)
+                {
+                    long remaining = payload.Length - ms.Position;
+                    if (remaining < HeaderSize)
+                    {
+                        return false;
+                    }
+
+                    long childStart = ms.Position;
+                    ms.Position += 4; // skip tag, peek at size
+                    uint size = reader.ReadUInt32();
+                    if (size == InvalidSize || size < HeaderSize || size > remaining)
+                    {
+                        return false;
+                    }
+
+                    ms.Position = childStart;
+                    EffectChunk child;
+                    try
+                    {
+                        child = Read(reader);
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+
+                    result.Add(child);
+                }
+            }
+
+            if (result.Count == 0)
+            {
+                return false;
+            }
+
+            children = result;
+            return true;
+        }
+
+        public void Write(BinaryWriter writer)
+        {
+            long start = writer.BaseStream.Position;
+            writer.Write(Tag);
+            writer.Write((uint)0); // size placeholder, patched below
+
+            if (Children != null)
+            {
+                foreach (EffectChunk child in Children)
+                {
+                    child.Write(writer);
+                }
+            }
+            else if (Data != null)
+            {
+                writer.Write(Data);
+            }
+
+            long end = writer.BaseStream.Position;
+            uint size = (uint)(end - start);
+            writer.BaseStream.Position = start + 4;
+            writer.Write(size);
+            writer.BaseStream.Position = end;
+        }
+
+        public void WriteXml(XmlWriter xml)
+        {
+            xml.WriteStartElement("Chunk");
+            xml.WriteAttributeString("tag", Tag.ToString(CultureInfo.InvariantCulture));
+
+            string name = EffectsTagNames.Lookup(Tag);
+            if (!string.IsNullOrEmpty(name))
+            {
+                xml.WriteAttributeString("name", name);
+            }
+
+            string operatorType = OperatorType;
+            if (!string.IsNullOrEmpty(operatorType))
+            {
+                xml.WriteAttributeString("operator", operatorType);
+            }
+
+            if (Children != null)
+            {
+                foreach (EffectChunk child in Children)
+                {
+                    child.WriteXml(xml);
+                }
+            }
+            else if (Data != null && Data.Length > 0)
+            {
+                xml.WriteAttributeString("data", Convert.ToHexString(Data));
+            }
+
+            xml.WriteEndElement();
+        }
+
+        public static EffectChunk ReadXml(XmlNode node)
+        {
+            EffectChunk chunk = new EffectChunk
+            {
+                Tag = uint.Parse(node.Attributes["tag"].Value, CultureInfo.InvariantCulture)
+            };
+
+            List<XmlNode> childElements = new List<XmlNode>();
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (child.NodeType == XmlNodeType.Element && child.Name == "Chunk")
+                {
+                    childElements.Add(child);
+                }
+            }
+
+            if (childElements.Count > 0)
+            {
+                chunk.Children = new List<EffectChunk>();
+                foreach (XmlNode childElement in childElements)
+                {
+                    chunk.Children.Add(ReadXml(childElement));
+                }
+            }
+            else
+            {
+                XmlAttribute dataAttr = node.Attributes["data"];
+                chunk.Data = dataAttr != null && !string.IsNullOrEmpty(dataAttr.Value)
+                    ? Convert.FromHexString(dataAttr.Value)
+                    : Array.Empty<byte>();
+            }
+
+            return chunk;
+        }
+
+        public override string ToString()
+        {
+            string operatorType = OperatorType;
+            string name = !string.IsNullOrEmpty(operatorType)
+                ? "Operator:" + operatorType
+                : EffectsTagNames.Lookup(Tag);
+
+            string label = string.IsNullOrEmpty(name)
+                ? string.Format(CultureInfo.InvariantCulture, "Chunk [{0}]", Tag)
+                : string.Format(CultureInfo.InvariantCulture, "{0} [{1}]", name, Tag);
+
+            return IsContainer
+                ? string.Format(CultureInfo.InvariantCulture, "{0} ({1} children, {2} bytes)", label, ChildCount, Size)
+                : string.Format(CultureInfo.InvariantCulture, "{0} ({1} bytes)", label, Size);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort, RE-derived names for a handful of tags that have a fixed meaning regardless
+    /// of context. These are display hints only; the parser is fully generic and does not depend
+    /// on them. (See C_EffectsLibrary::Load and C_Operator::Load.)
+    /// </summary>
+    public static class EffectsTagNames
+    {
+        private static readonly Dictionary<uint, string> Names = new Dictionary<uint, string>
+        {
+            { 666, "EffectsLibrary" }, // root magic (0x29A)
+            { 667, "LibraryHeader" },  // u32 read into the library
+            { 668, "Patterns" },       // container of C_EffectPattern chunks
+            { 669, "Version" },        // u32 version, expected == 2
+            { 300, "OperatorType" },   // 0x12C: operator type id chunk
+            { 350, "OperatorParams" }, // 0x15E: operator-specific parameter block
+            { 200, "Generation" },     // 0xC8: C_Generation chunk
+            { 123, "CurveKeys" },      // 0x7B: AnimParam keyframe-curve container
+            { 124, "CurveKey" },       // 0x7C: a single keyframe
+        };
+
+        public static string Lookup(uint tag)
+        {
+            return Names.TryGetValue(tag, out string name) ? name : null;
+        }
+    }
+
+    /// <summary>
+    /// ue::gfx::effects::E_OperatorType, recovered from C_Operator::CreateOperator. The id is the
+    /// first u32 inside an operator-type chunk (<see cref="EffectChunk.OperatorTypeTag"/>).
+    /// </summary>
+    public static class EffectsOperatorTypes
+    {
+        private static readonly string[] Names =
+        {
+            "Birth",            // 0
+            "Position",         // 1
+            "Speed",            // 2
+            "Texture",          // 3
+            "Rotation",         // 4
+            "Scale",            // 5
+            "Color",            // 6
+            "Shape",            // 7
+            "EmittingParticle", // 8
+            "Acceleration",     // 9
+            "Physics",          // 10
+            "LOD",              // 11
+            "Light",            // 12
+            "ScaleNU",          // 13
+            "MotionInheritance",// 14
+            "ColorHSV",         // 15
+            "Emissivity",       // 16
+            "ShiftedTexture",   // 17
+        };
+
+        public static string Lookup(uint id)
+        {
+            return id < Names.Length ? Names[id] : null;
+        }
+    }
+
+    /// <summary>A single parameter of an operator: either a scalar (floats) or an animated keyframe curve.</summary>
+    public class EffectParamInfo
+    {
+        public uint Tag { get; set; }            // operator-specific parameter slot
+        public string Name { get; set; }         // RE-inferred field name (may be null)
+        public bool IsAnimated { get; set; }     // true => keyframe curve, false => scalar
+        [Browsable(false)] public float[] Scalars { get; set; }     // when !IsAnimated
+        [Browsable(false)] public List<float[]> Keys { get; set; }  // when IsAnimated: each = [time, value0, ...]
+        public string Text { get; set; }         // embedded string (e.g. a resource name), if any
+
+        // Absolute byte offsets into the edit buffer for in-place editing.
+        [Browsable(false)] public int ScalarOffset { get; set; } = -1;          // first scalar float
+        [Browsable(false)] public List<int> KeyOffsets { get; set; }            // start of each key's floats
+
+        [Category("Parameter")]
+        public int KeyCount => Keys?.Count ?? 0;
+
+        [Category("Parameter")]
+        public string Values
+        {
+            get
+            {
+                if (Scalars != null && Scalars.Length > 0)
+                    return string.Join(", ", Array.ConvertAll(Scalars, f => f.ToString("0.######", CultureInfo.InvariantCulture)));
+                if (Keys != null && Keys.Count > 0)
+                {
+                    string[] parts = new string[Keys.Count];
+                    for (int i = 0; i < Keys.Count; i++)
+                        parts[i] = "[" + string.Join("/", Array.ConvertAll(Keys[i], f => f.ToString("0.###", CultureInfo.InvariantCulture))) + "]";
+                    return string.Join("  ", parts);
+                }
+                return string.Empty;
+            }
+        }
+
+        [Category("Parameter")]
+        public string Summary
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Text)) return "\"" + Text + "\"";
+                if (IsAnimated)
+                {
+                    int n = Keys?.Count ?? 0;
+                    if (n == 0) return "curve (empty)";
+                    float[] first = Keys[0];
+                    string firstStr = string.Join("/", Array.ConvertAll(first, f => f.ToString("0.###", CultureInfo.InvariantCulture)));
+                    return n == 1
+                        ? "constant " + firstStr
+                        : string.Format(CultureInfo.InvariantCulture, "curve, {0} keys (first {1})", n, firstStr);
+                }
+                if (Scalars != null && Scalars.Length > 0)
+                {
+                    return string.Join(", ", Array.ConvertAll(Scalars, f => f.ToString("0.###", CultureInfo.InvariantCulture)));
+                }
+                return "(empty)";
+            }
+        }
+
+        public override string ToString()
+        {
+            string label = string.IsNullOrEmpty(Name)
+                ? "param " + Tag.ToString(CultureInfo.InvariantCulture)
+                : Name;
+            return string.Format(CultureInfo.InvariantCulture, "{0}: {1}", label, Summary);
+        }
+    }
+
+    /// <summary>
+    /// RE-inferred operator parameter slot names, keyed by E_OperatorType then param slot tag.
+    /// Derived from each C_Operator*::LoadSpecific (member offsets + loader kind) and cross-checked
+    /// against real effect data. Names are best-effort; unknown slots fall back to "param N".
+    /// </summary>
+    public static class EffectsOperatorParamNames
+    {
+        private static readonly Dictionary<uint, Dictionary<uint, string>> Names =
+            new Dictionary<uint, Dictionary<uint, string>>
+        {
+            { 0,  new Dictionary<uint, string> { {0,"Rate"} } },                          // Birth
+            { 1,  new Dictionary<uint, string> { {0,"WorldSpace"}, {1,"Space"} } },        // Position
+            { 2,  new Dictionary<uint, string> { {0,"Speed"}, {5,"Direction"} } },         // Speed
+            { 3,  new Dictionary<uint, string> { {8,"UV Rect"} } },                        // Texture
+            { 4,  new Dictionary<uint, string> { {1,"Axis"}, {6,"Angle"} } },              // Rotation
+            { 5,  new Dictionary<uint, string> { {0,"Size"}, {1,"Size 2"} } },             // Scale
+            { 6,  new Dictionary<uint, string> { {0,"Color (RGB)"}, {1,"Alpha"} } },       // Color
+            { 9,  new Dictionary<uint, string> { {0,"Acceleration"}, {1,"Magnitude"} } },  // Acceleration
+            { 13, new Dictionary<uint, string> { {0,"Size X"}, {1,"Size Y"} } },           // ScaleNU
+            { 15, new Dictionary<uint, string> { {0,"Alpha"}, {1,"Color (HSV)"} } },       // ColorHSV
+        };
+
+        public static string Lookup(uint operatorType, uint slot)
+        {
+            return Names.TryGetValue(operatorType, out var m) && m.TryGetValue(slot, out string n) ? n : null;
+        }
+    }
+
+    /// <summary>One operator inside a generation (a tag-300 chunk; payload = u32 type, u8 enabled, params).</summary>
+    public class EffectOperatorInfo
+    {
+        [Category("Operator")] public uint TypeId { get; set; }
+        [Category("Operator")] public string Type { get; set; }
+        [Category("Operator")] public bool Enabled { get; set; }
+        [Category("Operator")] public int ParameterCount => Parameters?.Count ?? 0;
+        [Browsable(false)] public List<EffectParamInfo> Parameters { get; set; } = new List<EffectParamInfo>();
+
+        public override string ToString()
+        {
+            string name = Type ?? ("Operator(" + TypeId + ")");
+            string en = Enabled ? "" : " (disabled)";
+            return Parameters.Count > 0
+                ? string.Format(CultureInfo.InvariantCulture, "{0}{1} — {2} params", name, en, Parameters.Count)
+                : name + en;
+        }
+    }
+
+    /// <summary>A named generation (emitter) inside an effect — a tag-200 chunk.</summary>
+    public class EffectGenerationInfo
+    {
+        [Category("Generation")] public string Name { get; set; }
+        [Category("Generation")] public int OperatorCount => Operators?.Count ?? 0;
+        [Browsable(false)] public List<EffectOperatorInfo> Operators { get; set; } = new List<EffectOperatorInfo>();
+
+        [Category("Generation")]
+        public string OperatorList => string.Join(", ", Operators.ConvertAll(o => o.Type ?? o.TypeId.ToString()));
+
+        public override string ToString()
+        {
+            string ops = Operators.Count == 0 ? "no operators"
+                : string.Join(", ", Operators.ConvertAll(o => o.ToString()));
+            return string.Format(CultureInfo.InvariantCulture, "Generation \"{0}\"  —  {1}",
+                string.IsNullOrEmpty(Name) ? "(unnamed)" : Name, ops);
+        }
+    }
+
+    /// <summary>A frame (emitter transform node) attached to an effect — a tag-100 chunk.</summary>
+    public class EffectFrameInfo
+    {
+        public int Index;
+        public uint ClassId;      // C_FrameClassFactory class id (3rd u32 of the frame header)
+        public float[] Transform; // leading floats of the frame header (position/orientation)
+
+        /// <summary>Best-effort frame-class name. 65 is the standard effect emitter frame (most common).</summary>
+        public string TypeName
+        {
+            get
+            {
+                switch (ClassId)
+                {
+                    case 65: return "Emitter";
+                    default: return "Frame(" + ClassId + ")";
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            if (Transform != null && Transform.Length >= 3)
+            {
+                return string.Format(CultureInfo.InvariantCulture, "{0} #{1}  pos=({2}, {3}, {4})",
+                    TypeName, Index, Transform[0].ToString("0.###", CultureInfo.InvariantCulture),
+                    Transform[1].ToString("0.###", CultureInfo.InvariantCulture),
+                    Transform[2].ToString("0.###", CultureInfo.InvariantCulture));
+            }
+            return TypeName + " #" + Index;
+        }
+    }
+
+    /// <summary>A sound element attached to an effect — a tag-400 chunk.</summary>
+    public class EffectSoundInfo
+    {
+        public string Name;
+        public override string ToString() => "Sound" + (string.IsNullOrEmpty(Name) ? "" : " \"" + Name + "\"");
+    }
+
+    /// <summary>An effect (pattern) — a tag-0 chunk under Patterns (668).</summary>
+    public class EffectPatternInfo
+    {
+        [Category("Effect")] public uint Id { get; set; }
+        [Category("Effect")] public int FrameCount => Frames?.Count ?? 0;
+        [Category("Effect")] public int SoundCount => Sounds?.Count ?? 0;
+        [Category("Effect")] public int GenerationCount => Generations?.Count ?? 0;
+        [Browsable(false)] public List<EffectFrameInfo> Frames { get; set; } = new List<EffectFrameInfo>();
+        [Browsable(false)] public List<EffectSoundInfo> Sounds { get; set; } = new List<EffectSoundInfo>();
+        [Browsable(false)] public List<EffectGenerationInfo> Generations { get; set; } = new List<EffectGenerationInfo>();
+
+        /// <summary>Best human-readable name: the first non-default generation name, else the index.</summary>
+        [Category("Effect")]
+        public string DisplayName
+        {
+            get
+            {
+                foreach (EffectGenerationInfo g in Generations)
+                {
+                    if (!string.IsNullOrEmpty(g.Name) && !g.Name.StartsWith("Generation", StringComparison.Ordinal))
+                    {
+                        return g.Name;
+                    }
+                }
+                foreach (EffectGenerationInfo g in Generations)
+                {
+                    if (!string.IsNullOrEmpty(g.Name)) return g.Name;
+                }
+                return "Effect " + Id;
+            }
+        }
+
+        /// <summary>Coarse classification derived from the operators present.</summary>
+        public string Kind
+        {
+            get
+            {
+                HashSet<string> ops = new HashSet<string>();
+                foreach (EffectGenerationInfo g in Generations)
+                    foreach (EffectOperatorInfo o in g.Operators)
+                        if (o.Type != null) ops.Add(o.Type);
+
+                if (ops.Count == 0) return FrameCount > 0 ? "Frames only" : "Empty";
+
+                List<string> traits = new List<string>();
+                if (ops.Contains("Texture") || ops.Contains("ShiftedTexture")) traits.Add("Textured");
+                if (ops.Contains("Color") || ops.Contains("ColorHSV")) traits.Add("Colored");
+                if (ops.Contains("Light")) traits.Add("Light");
+                if (ops.Contains("Physics")) traits.Add("Physics");
+                bool particle = ops.Contains("Birth");
+
+                string baseKind = particle ? "Particle" : "Effect";
+                return traits.Count > 0 ? baseKind + " (" + string.Join(", ", traits) + ")" : baseKind;
+            }
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "Effect #{0} \"{1}\"  [{2}]  — {3} gen, {4} frames",
+                Id, DisplayName, Kind, Generations.Count, FrameCount);
+        }
+    }
+
+    /// <summary>
+    /// Schema-guided reader that turns a parsed .eff into a readable list of effects, generations
+    /// and operator types. Unlike the generic chunk tree it follows the known layout
+    /// (Patterns 668 -> Pattern[id] -> Generations 2 -> Generation 200{Name 0, Operators 3/4 -> 300}).
+    /// </summary>
+    public static class EffectsSummary
+    {
+        private const uint PatternsTag = 668;
+        private const uint GenerationsTag = 2;
+        private const uint FramesTag = 1;
+        private const uint GenerationChunkTag = 200;
+        private const uint FrameChunkTag = 100;
+        private const uint FrameHeaderTag = 101;
+        private const uint SoundChunkTag = 400; // 0x190
+        private const uint NameTag = 0;
+        private const uint OperatorChunkTag = 300;
+
+        public static List<EffectPatternInfo> Parse(byte[] eff)
+        {
+            List<EffectPatternInfo> result = new List<EffectPatternInfo>();
+            try
+            {
+                // root chunk -> find Patterns (668)
+                foreach (var rootChild in Tile(eff, 8, eff.Length - 8))
+                {
+                    if (rootChild.Tag != PatternsTag) continue;
+
+                    foreach (var pat in Tile(eff, rootChild.Start, rootChild.Length))
+                    {
+                        // pattern payload prefix = u32 version, u32 id
+                        if (pat.Length < 8) continue;
+                        EffectPatternInfo info = new EffectPatternInfo
+                        {
+                            Id = BitConverter.ToUInt32(eff, pat.Start + 4)
+                        };
+
+                        foreach (var sub in Tile(eff, pat.Start + 8, pat.Length - 8))
+                        {
+                            if (sub.Tag == FramesTag)
+                            {
+                                int fi = 0;
+                                foreach (var fr in Tile(eff, sub.Start, sub.Length))
+                                    if (fr.Tag == FrameChunkTag)
+                                        info.Frames.Add(ParseFrame(eff, fr.Start, fr.Length, fi++));
+                            }
+                            else if (sub.Tag == GenerationsTag)
+                            {
+                                foreach (var gen in Tile(eff, sub.Start, sub.Length))
+                                    if (gen.Tag == GenerationChunkTag)
+                                        info.Generations.Add(ParseGeneration(eff, gen.Start, gen.Length));
+                            }
+                            else
+                            {
+                                // The pattern's "default" branch loads sound elements (tag-400 chunks).
+                                foreach (var s in Tile(eff, sub.Start, sub.Length))
+                                    if (s.Tag == SoundChunkTag)
+                                        info.Sounds.Add(new EffectSoundInfo { Name = ExtractString(eff, s.Start, s.Length) });
+                            }
+                        }
+
+                        result.Add(info);
+                    }
+                }
+            }
+            catch
+            {
+                // best-effort: return whatever parsed
+            }
+            return result;
+        }
+
+        private static EffectFrameInfo ParseFrame(byte[] eff, int start, int length, int index)
+        {
+            EffectFrameInfo frame = new EffectFrameInfo { Index = index };
+            if (length >= 12) frame.ClassId = BitConverter.ToUInt32(eff, start + 8); // 3rd u32 = frame class id
+            // The frame payload may carry a small raw prefix before its [101] header chunk.
+            foreach (int pre in new[] { 0, 4, 8, 12, 16 })
+            {
+                if (pre > length) break;
+                foreach (var sub in Tile(eff, start + pre, length - pre))
+                {
+                    if (sub.Tag == FrameHeaderTag)
+                    {
+                        frame.Transform = ReadFloats(eff, sub.Start, Math.Min(sub.Length, 48));
+                        return frame;
+                    }
+                }
+            }
+            return frame;
+        }
+
+        private static EffectGenerationInfo ParseGeneration(byte[] eff, int start, int length)
+        {
+            EffectGenerationInfo gen = new EffectGenerationInfo();
+            foreach (var sub in Tile(eff, start, length))
+            {
+                if (sub.Tag == NameTag)
+                {
+                    gen.Name = ExtractString(eff, sub.Start, sub.Length);
+                }
+                else // operators live under tag 3 or 4
+                {
+                    foreach (var op in Tile(eff, sub.Start, sub.Length))
+                    {
+                        if (op.Tag == OperatorChunkTag && op.Length >= 4)
+                        {
+                            gen.Operators.Add(ParseOperator(eff, op.Start, op.Length));
+                        }
+                    }
+                }
+            }
+            return gen;
+        }
+
+        private const uint OperatorParamsTag = 350; // 0x15E
+        private const uint CurveKeysTag = 123;       // 0x7B
+        private const uint CurveKeyTag = 124;        // 0x7C
+
+        /// <summary>Operator payload = u32 typeId, u8 enabled, then a [350] params block of scalar/curve params.</summary>
+        private static EffectOperatorInfo ParseOperator(byte[] eff, int start, int length)
+        {
+            uint typeId = BitConverter.ToUInt32(eff, start);
+            EffectOperatorInfo op = new EffectOperatorInfo
+            {
+                TypeId = typeId,
+                Type = EffectsOperatorTypes.Lookup(typeId),
+                Enabled = length >= 5 ? eff[start + 4] != 0 : true
+            };
+
+            // Sub-chunks start after the 5-byte (typeId + enabled) prefix.
+            foreach (var sub in Tile(eff, start + 5, length - 5))
+            {
+                if (sub.Tag != OperatorParamsTag) continue; // [350]
+                foreach (var p in Tile(eff, sub.Start, sub.Length))
+                {
+                    op.Parameters.Add(ParseParam(eff, typeId, p.Tag, p.Start, p.Length));
+                }
+            }
+            return op;
+        }
+
+        private static EffectParamInfo ParseParam(byte[] eff, uint operatorType, uint tag, int start, int length)
+        {
+            EffectParamInfo param = new EffectParamInfo { Tag = tag, Name = EffectsOperatorParamNames.Lookup(operatorType, tag) };
+
+            // Animated params carry an 8-byte prefix (mode u32==1, kind u32) then a [123] curve.
+            // Detect by looking for a CurveKeys chunk after a 0/8-byte prefix.
+            int curveStart, curveLen;
+            if (FindCurve(eff, start, length, out curveStart, out curveLen))
+            {
+                param.IsAnimated = true;
+                param.Keys = new List<float[]>();
+                param.KeyOffsets = new List<int>();
+                CollectKeys(eff, curveStart, curveLen, param.Keys, param.KeyOffsets);
+                return param;
+            }
+
+            // Otherwise scalar: try a string first, else floats.
+            string text = TryReadName(eff, start, length);
+            if (text != null && text.Length >= 3)
+            {
+                param.Text = text;
+            }
+            else
+            {
+                param.Scalars = ReadFloats(eff, start, length);
+                param.ScalarOffset = start;
+            }
+            return param;
+        }
+
+        /// <summary>Locate a [123] CurveKeys chunk inside a param payload (allowing the 8-byte AnimParam prefix).</summary>
+        private static bool FindCurve(byte[] eff, int start, int length, out int cStart, out int cLen)
+        {
+            foreach (int pre in new[] { 0, 8, 4 })
+            {
+                if (pre > length) continue;
+                foreach (var s in Tile(eff, start + pre, length - pre))
+                {
+                    if (s.Tag == CurveKeysTag) { cStart = s.Start; cLen = s.Length; return true; }
+                }
+            }
+            cStart = 0; cLen = 0; return false;
+        }
+
+        /// <summary>Recursively gather innermost keyframes; each [124] leaf payload yields its leading floats as [time, value...].</summary>
+        private static void CollectKeys(byte[] eff, int start, int length, List<float[]> keys, List<int> offsets)
+        {
+            // [123] body = u32 keyCount prefix, then [124] keys.
+            foreach (int pre in new[] { 4, 0 })
+            {
+                if (pre > length) continue;
+                var spans = Tile(eff, start + pre, length - pre);
+                if (spans.Count == 0) continue;
+
+                foreach (var key in spans)
+                {
+                    if (key.Tag != CurveKeyTag) continue;
+
+                    // A key may nest a deeper [123] (the 2nd curve dimension); recurse to the leaf.
+                    int innerStart, innerLen;
+                    if (FindCurve(eff, key.Start, key.Length, out innerStart, out innerLen))
+                    {
+                        CollectKeys(eff, innerStart, innerLen, keys, offsets);
+                    }
+                    else
+                    {
+                        float[] f = ReadFloats(eff, key.Start, Math.Min(key.Length, 20)); // time + up to 4 values
+                        if (f.Length > 0) { keys.Add(f); offsets.Add(key.Start); }
+                    }
+                }
+                if (keys.Count > 0) return;
+            }
+        }
+
+        private static float[] ReadFloats(byte[] eff, int start, int length)
+        {
+            // skip a possible small chunk-prefix of zero bytes is not needed; just read whole range
+            int count = length / 4;
+            if (count <= 0) return Array.Empty<float>();
+            float[] f = new float[count];
+            for (int i = 0; i < count; i++) f[i] = BitConverter.ToSingle(eff, start + i * 4);
+            return f;
+        }
+
+        private static string TryReadName(byte[] eff, int start, int length)
+        {
+            string s = ExtractString(eff, start, length);
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+
+        private struct Span { public uint Tag; public int Start; public int Length; }
+
+        /// <summary>Walk [offset, offset+len) as back-to-back chunks; yields header-stripped spans. Stops on any malformed chunk.</summary>
+        private static List<Span> Tile(byte[] buf, int offset, int len)
+        {
+            List<Span> spans = new List<Span>();
+            int i = offset;
+            int end = offset + len;
+            while (i + 8 <= end)
+            {
+                uint tag = BitConverter.ToUInt32(buf, i);
+                uint size = BitConverter.ToUInt32(buf, i + 4);
+                if (size < 8 || i + size > end) break;
+                spans.Add(new Span { Tag = tag, Start = i + 8, Length = (int)size - 8 });
+                i += (int)size;
+            }
+            return spans;
+        }
+
+        /// <summary>Names are stored as [u16 length][ascii]; fall back to the longest printable run.</summary>
+        private static string ExtractString(byte[] buf, int start, int length)
+        {
+            if (length >= 2)
+            {
+                int slen = BitConverter.ToUInt16(buf, start);
+                if (slen > 0 && slen <= length - 2)
+                {
+                    bool printable = true;
+                    for (int j = 0; j < slen; j++)
+                    {
+                        byte b = buf[start + 2 + j];
+                        if (b < 0x20 || b > 0x7e) { printable = false; break; }
+                    }
+                    if (printable) return System.Text.Encoding.ASCII.GetString(buf, start + 2, slen);
+                }
+            }
+
+            // fallback: longest printable ASCII run
+            string best = string.Empty;
+            int runStart = -1;
+            for (int j = 0; j <= length; j++)
+            {
+                bool ok = j < length && buf[start + j] >= 0x20 && buf[start + j] <= 0x7e;
+                if (ok && runStart < 0) runStart = j;
+                else if (!ok && runStart >= 0)
+                {
+                    if (j - runStart > best.Length)
+                        best = System.Text.Encoding.ASCII.GetString(buf, start + runStart, j - runStart);
+                    runStart = -1;
+                }
+            }
+            return best;
+        }
+    }
+
+    /// <summary>
+    /// Top-level container for a ".eff" file. A real .eff is a single root chunk (tag 666) spanning
+    /// the whole stream, but this supports multiple top-level chunks for robustness.
+    /// </summary>
+    public class EffectsFile
+    {
+        public List<EffectChunk> Roots { get; set; } = new List<EffectChunk>();
+
+        /// <summary>
+        /// Set to the verbatim original bytes when the parsed tree could not reproduce them
+        /// byte-for-byte. When set, Save writes these bytes unchanged so a file is never corrupted.
+        /// </summary>
+        public byte[] RawFallback { get; private set; }
+
+        public bool IsRawFallback => RawFallback != null;
+
+        public void ReadFromFile(string path)
+        {
+            ReadFromBytes(File.ReadAllBytes(path));
+        }
+
+        public void ReadFromBytes(byte[] original)
+        {
+            Roots = new List<EffectChunk>();
+            RawFallback = null;
+
+            try
+            {
+                using (MemoryStream ms = new MemoryStream(original, false))
+                using (BinaryReader reader = new BinaryReader(ms))
+                {
+                    while (ms.Position < original.Length)
+                    {
+                        if (original.Length - ms.Position < EffectChunk.HeaderSize)
+                        {
+                            throw new InvalidDataException("Trailing bytes are smaller than a chunk header.");
+                        }
+
+                        Roots.Add(EffectChunk.Read(reader));
+                    }
+                }
+
+                // Guarantee a lossless round-trip; otherwise treat the whole file as opaque.
+                if (!BytesEqual(WriteToBytes(), original))
+                {
+                    RawFallback = original;
+                    Roots = new List<EffectChunk>();
+                }
+            }
+            catch
+            {
+                RawFallback = original;
+                Roots = new List<EffectChunk>();
+            }
+        }
+
+        // Mutable buffer used for in-place typed value edits (keyframes/scalars). The summary
+        // records absolute offsets into this exact buffer so edits map back losslessly.
+        private byte[] _editBuffer;
+
+        /// <summary>True when a typed value edit (keyframe/scalar) has been applied in place.</summary>
+        public bool TypedEdited { get; private set; }
+
+        /// <summary>Readable list of effects (patterns) with their generation names and operator types.</summary>
+        public List<EffectPatternInfo> GetSummary()
+        {
+            if (_editBuffer == null)
+            {
+                _editBuffer = BuildBytes();
+            }
+            return EffectsSummary.Parse(_editBuffer);
+        }
+
+        /// <summary>Patch a 32-bit float at an absolute offset (in-place, same size — round-trip safe).</summary>
+        public void PatchFloat(int offset, float value)
+        {
+            if (_editBuffer == null)
+            {
+                _editBuffer = BuildBytes();
+            }
+            byte[] bytes = BitConverter.GetBytes(value);
+            Array.Copy(bytes, 0, _editBuffer, offset, 4);
+            TypedEdited = true;
+        }
+
+        private byte[] BuildBytes()
+        {
+            if (RawFallback != null)
+            {
+                return (byte[])RawFallback.Clone();
+            }
+
+            using (MemoryStream ms = new MemoryStream())
+            using (BinaryWriter writer = new BinaryWriter(ms))
+            {
+                foreach (EffectChunk root in Roots)
+                {
+                    root.Write(writer);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+        public byte[] WriteToBytes()
+        {
+            if (TypedEdited && _editBuffer != null)
+            {
+                return (byte[])_editBuffer.Clone();
+            }
+            return BuildBytes();
+        }
+
+        public void WriteToFile(string path)
+        {
+            File.WriteAllBytes(path, WriteToBytes());
+        }
+
+        public void ConvertToXML(string path)
+        {
+            XmlWriterSettings settings = new XmlWriterSettings
+            {
+                Indent = true,
+                IndentChars = "\t",
+                OmitXmlDeclaration = false
+            };
+
+            using (XmlWriter xml = XmlWriter.Create(path, settings))
+            {
+                xml.WriteStartElement("Effects");
+
+                if (RawFallback != null)
+                {
+                    // File could not be parsed losslessly; preserve it verbatim.
+                    xml.WriteAttributeString("raw", Convert.ToHexString(RawFallback));
+                }
+                else
+                {
+                    foreach (EffectChunk root in Roots)
+                    {
+                        root.WriteXml(xml);
+                    }
+                }
+
+                xml.WriteEndElement();
+            }
+        }
+
+        public void ConvertFromXML(string path)
+        {
+            XmlDocument document = new XmlDocument();
+            document.Load(path);
+
+            XmlNode root = document.DocumentElement;
+            Roots = new List<EffectChunk>();
+            RawFallback = null;
+
+            if (root == null)
+            {
+                return;
+            }
+
+            XmlAttribute rawAttr = root.Attributes["raw"];
+            if (rawAttr != null && !string.IsNullOrEmpty(rawAttr.Value))
+            {
+                RawFallback = Convert.FromHexString(rawAttr.Value);
+                return;
+            }
+
+            foreach (XmlNode child in root.ChildNodes)
+            {
+                if (child.NodeType == XmlNodeType.Element && child.Name == "Chunk")
+                {
+                    Roots.Add(EffectChunk.ReadXml(child));
+                }
+            }
+        }
+
+        private static bool BytesEqual(byte[] a, byte[] b)
+        {
+            if (ReferenceEquals(a, b))
+            {
+                return true;
+            }
+
+            if (a == null || b == null || a.Length != b.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds full support for the Mafia II **`.eff`** file format (the SDS **Effects** resource), which the toolkit previously extracted only as an opaque blob. The format was reverse-engineered from the game binary; this PR adds a parser, a typed inspector/editor, MCP tooling, and localization.

## Format (reverse-engineered)

Little-endian TLV tree: `chunk = [tag:u32][size:u32 incl 8-byte header][payload]`. Container chunks pack child chunks back-to-back (no padding); leaves hold raw data. Derived from `C_InputChunk`, `C_EffectsLibrary::Load`, `C_EffectPattern::Load`, `C_Operator::Load` / `CreateOperator`, `C_Generation::Load`, the `C_Operator*::LoadSpecific` family, the `C_AnimParam2D` keyframe-curve loaders, and `C_FrameClassFactory`.

```
666 EffectsLibrary
 ├ 669 Version (==2), 667 header
 └ 668 Patterns → Pattern{u32 ver, u32 id, sub-chunks}
     ├ 1 Frames   → Frame(100)  (emitter transform; class id via C_FrameClassFactory; 65 = Emitter)
     ├ 2 Generations → Generation(200){ 0 Name, 3/4 Operators }
     │     └ Operator(300){ u32 E_OperatorType, bool enabled, 350 params }
     │           └ param = scalar | AnimParam2D keyframe curve (123 keyCount / 124 keys: time,value…)
     └ default → Sound(400)
```

`E_OperatorType` (0–17) fully recovered: Birth, Position, Speed, Texture, Rotation, Scale, Color, Shape, EmittingParticle, Acceleration, Physics, LOD, Light, ScaleNU, MotionInheritance, ColorHSV, Emissivity, ShiftedTexture.

## What's included

**Parser / model** (`EffectsFile`, `EffectChunk`)
- Generic chunk tree with **byte-exact round-trip** and a raw-passthrough fallback (never corrupts a file it can't parse losslessly).
- XML import/export; in-place float patching for value edits.

**Typed inspector** (`EffectsSummary`)
- Effects named by their generation(s) and classified by operator set (e.g. *Particle (Textured, Colored)*).
- Operators carry the `E_OperatorType` enum, an `enabled` flag, and RE-inferred parameter names (Rate / Speed / Angle / Size / Color / UV Rect…).
- Animated params decode to keyframe lists (`time/value…`); scalars to floats.
- Frames (emitters, with class id + position) and sound elements listed.

**Editor** (`EffectsEditor`)
- TreeView (Effects → Generations → Operators → Params) + PropertyGrid + an editable value/keyframe grid.
- Edit scalar/keyframe values, and **add/remove keyframes** (right-click the grid) on simple curves — implemented by splicing the `[124]` key chunk, bumping the `[123]` key count, and cascading the size delta through every enclosing chunk's size field (all adjusted fields precede the edit point, so offsets stay valid). Add-then-remove is byte-exact.
- Fully **localized** via `Language.GetString`; reuses existing keys and adds `$EFFECTS_EDITOR_TITLE`, `$EFF_ADD_KEY`, `$EFF_REMOVE_KEY` to all 7 locale files (English everywhere, French translation in `fr_FR`).

**Integration**
- `FileEffects` + `FileFactory` registration for `.eff` (opens the editor). SDS repack already reads the edited `.eff` back via `WriteBasicEntry`, so no archive-side change was needed.
- **MCP tools**: `parse_effects_file` and `parse_effects_from_bytes` (the latter composes with `extract_resource`) return the effect list or full per-effect detail; `detect_file_format` / `detect_format_from_bytes` now recognize `.eff` (root tag 666). Auto-registered via `WithToolsFromAssembly`.

## Validation

Tested against a real ~1.9 MB effects library exported from the toolkit:
- All **358 effects** parse with **no raw fallback**; round-trip is byte-exact.
- Value edits, and **keyframe add-then-remove return the original bytes exactly**.
- MCP tools return correct, well-formed JSON in both list and per-effect detail modes.
- Project builds clean (0 errors); all 7 locale XML files validated well-formed.

## Commits

1. Add Mafia II .eff (Effects) file format support
2. Add keyframe insert/remove to the .eff curve editor
3. Localize the .eff effects editor
4. Expose .eff effects parser via MCP tools

## Notes / limitations

- Parameter names and the dominant frame type ("Emitter", class id 65) are RE-inferred; ambiguous param slots and the 3 rare frame ids stay generic rather than risk mislabeling.
- Keyframe add/remove is enabled only for simple single-`[123]` curves (multi-curve/2D params are flagged and are value-edit only).
- Texture operators reference textures by index (the `.dds` name isn't stored in the `.eff`), so texture names aren't resolved here.
- Non-English locales use English placeholders for the 3 new keys, pending translation.
- The Toolkit-hosted MCP server exposes the new tools after a rebuild/restart.
- Not yet verified in-game; needs a load test in Mafia II.
